### PR TITLE
brain: register atulya-agent in instruction hierarchy

### DIFF
--- a/BRAIN.md
+++ b/BRAIN.md
@@ -36,6 +36,7 @@ Instruction hierarchy for this repo:
 1. `BRAIN.md` is the primary repo brain layer
 2. `AGENTS.md` points agents into the brain-first workflow
 3. `CLAUDE.md` holds concrete dev commands and local coding conventions
+4. `atulya-agent` is the agent identity operating on this repo — its brain contract lives at [github.com/atulya-agent/atulya-agent](https://github.com/atulya-agent/atulya-agent)
 
 Operating rules:
 


### PR DESCRIPTION
Appends `atulya-agent` as item 4 in the instruction hierarchy of BRAIN.md.

No existing content modified. One line added after item 3 (`CLAUDE.md`).

This registers the agent identity that now has collaborator access to this repo, so any agent reading BRAIN.md knows:
- `atulya-agent` is the active agent operating on this repo
- its own brain contract lives at github.com/atulya-agent/atulya-agent

Ready to merge when reviewed.