### PR TITLE
[feature] ~ plasticity: DSPy + TextGrad optimizer/compiler for LLM programs

### DIFF
--- a/atulya-cortex/cortex/cli_commands/plasticity.py
+++ b/atulya-cortex/cortex/cli_commands/plasticity.py
@@ -1,0 +1,359 @@
+"""plasticity — compile and optimize LLM programs.
+
+Subcommands:
+
+- `atulya-cortex plasticity compile <program.json> <trainset.jsonl>`
+    bootstrap few-shot demos and write the compiled program to the output path
+    (defaults to `<home>/plasticity/<program_name>.compiled.json`).
+
+- `atulya-cortex plasticity optimize <program.json> <trainset.jsonl>`
+    textual-gradient optimization of the program's instructions.
+
+- `atulya-cortex plasticity evaluate <program.json> <testset.jsonl>`
+    run the program on the testset and print an EvalReport summary.
+
+- `atulya-cortex plasticity run <program.json>`
+    read one input record from stdin (or `--input`) and print the parsed
+    program output as JSON.
+
+Program files are JSON in the shape `Program.to_dict()` produces. Datasets
+are JSONL where each line is `{"inputs": {...}, "outputs": {...}}`.
+
+The command instantiates a `cortex.language.Language` from the active
+profile's config so `plasticity` speaks to whichever provider the user
+already configured. No separate auth story.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from cortex import config as cortex_config
+from cortex.config import ConfigError
+from cortex.language import Language, Provider
+from plasticity import (
+    BootstrapReport,
+    Compiler,
+    Example,
+    GradientReport,
+    Program,
+    TextGradient,
+    evaluate,
+    exact_match,
+    load_compiled,
+    save_compiled,
+)
+from plasticity.metric import Metric
+
+NAME = "plasticity"
+HELP = "Compile, optimize, or evaluate LLM programs (DSPy + TextGrad)."
+
+
+def register(subparsers, common_parents) -> None:
+    parser = subparsers.add_parser(
+        NAME,
+        help=HELP,
+        parents=list(common_parents),
+        description="The cortex's neuroplasticity toolkit — compile and optimize LLM programs.",
+    )
+    sub = parser.add_subparsers(dest="plasticity_command", metavar="<action>")
+
+    _register_compile(sub, common_parents)
+    _register_optimize(sub, common_parents)
+    _register_evaluate(sub, common_parents)
+    _register_run(sub, common_parents)
+
+    parser.set_defaults(_run=run)
+
+
+def run(args: argparse.Namespace, *, home) -> int:
+    handler = getattr(args, "_plasticity_run", None)
+    if handler is None:
+        sys.stderr.write("error: specify a plasticity subcommand (compile|optimize|evaluate|run)\n")
+        return 2
+    return handler(args, home=home)
+
+
+# ---------------------------------------------------------------------------
+# Subcommand wiring
+# ---------------------------------------------------------------------------
+
+
+def _register_compile(sub, common_parents) -> None:
+    p = sub.add_parser(
+        "compile",
+        parents=list(common_parents),
+        help="Bootstrap few-shot demos into a compiled program JSON.",
+    )
+    p.add_argument("program", type=Path, help="Path to a Program JSON file.")
+    p.add_argument("trainset", type=Path, help="Path to JSONL trainset.")
+    p.add_argument("--valset", type=Path, default=None, help="Optional JSONL valset (score baseline vs compiled).")
+    p.add_argument("--metric-field", default=None, help="Output field used by the default exact_match metric.")
+    p.add_argument("--out", type=Path, default=None, help="Where to write the compiled program JSON.")
+    p.add_argument("--max-demos", type=int, default=4)
+    p.add_argument("--backend", choices=("auto", "local", "dspy"), default="auto")
+    p.add_argument("--provider", default=None)
+    p.add_argument("--model", default=None)
+    p.set_defaults(_plasticity_run=_run_compile)
+
+
+def _register_optimize(sub, common_parents) -> None:
+    p = sub.add_parser(
+        "optimize",
+        parents=list(common_parents),
+        help="Textual-gradient optimization of the program instructions.",
+    )
+    p.add_argument("program", type=Path)
+    p.add_argument("trainset", type=Path)
+    p.add_argument("--valset", type=Path, default=None)
+    p.add_argument("--metric-field", default=None)
+    p.add_argument("--steps", type=int, default=3)
+    p.add_argument("--out", type=Path, default=None)
+    p.add_argument("--backend", choices=("auto", "local", "textgrad"), default="auto")
+    p.add_argument("--provider", default=None)
+    p.add_argument("--model", default=None)
+    p.set_defaults(_plasticity_run=_run_optimize)
+
+
+def _register_evaluate(sub, common_parents) -> None:
+    p = sub.add_parser(
+        "evaluate",
+        parents=list(common_parents),
+        help="Run the program on a testset and print the EvalReport.",
+    )
+    p.add_argument("program", type=Path)
+    p.add_argument("testset", type=Path)
+    p.add_argument("--metric-field", default=None)
+    p.add_argument("--provider", default=None)
+    p.add_argument("--model", default=None)
+    p.set_defaults(_plasticity_run=_run_evaluate)
+
+
+def _register_run(sub, common_parents) -> None:
+    p = sub.add_parser(
+        "run",
+        parents=list(common_parents),
+        help="Run a compiled program on one input record.",
+    )
+    p.add_argument("program", type=Path)
+    p.add_argument("--input", type=Path, default=None, help="JSON file with an inputs object; defaults to stdin.")
+    p.add_argument("--provider", default=None)
+    p.add_argument("--model", default=None)
+    p.set_defaults(_plasticity_run=_run_once)
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+
+def _run_compile(args: argparse.Namespace, *, home) -> int:
+    program = _load_program(args.program)
+    trainset = _load_dataset(args.trainset)
+    valset = _load_dataset(args.valset) if args.valset else None
+    metric = _build_metric(program, args.metric_field)
+
+    language = _build_language(home)
+    try:
+        compiler = Compiler(max_demos=args.max_demos)
+        compiled, report = asyncio.run(
+            compiler.compile(
+                program,
+                language,
+                trainset=trainset,
+                metric=metric,
+                valset=valset,
+                backend=args.backend,
+                provider=args.provider,
+                model=args.model,
+            )
+        )
+    finally:
+        asyncio.run(language.aclose())
+
+    out_path = args.out or _default_out_path(home, args.program, "compiled")
+    save_compiled(out_path, compiled, meta={"source": str(args.program)})
+    _print_bootstrap_report(report, out_path)
+    return 0
+
+
+def _run_optimize(args: argparse.Namespace, *, home) -> int:
+    program = _load_program(args.program)
+    trainset = _load_dataset(args.trainset)
+    valset = _load_dataset(args.valset) if args.valset else None
+    metric = _build_metric(program, args.metric_field)
+
+    language = _build_language(home)
+    try:
+        grad = TextGradient()
+        tuned, report = asyncio.run(
+            grad.optimize(
+                program,
+                language,
+                trainset=trainset,
+                metric=metric,
+                valset=valset,
+                steps=args.steps,
+                backend=args.backend,
+                provider=args.provider,
+                model=args.model,
+            )
+        )
+    finally:
+        asyncio.run(language.aclose())
+
+    out_path = args.out or _default_out_path(home, args.program, "optimized")
+    save_compiled(out_path, tuned, meta={"source": str(args.program), "steps": args.steps})
+    _print_gradient_report(report, out_path)
+    return 0
+
+
+def _run_evaluate(args: argparse.Namespace, *, home) -> int:
+    program = _load_program(args.program)
+    testset = _load_dataset(args.testset)
+    metric = _build_metric(program, args.metric_field)
+
+    language = _build_language(home)
+    try:
+        report = asyncio.run(
+            evaluate(
+                program,
+                language,
+                testset,
+                metric,
+                provider=args.provider,
+                model=args.model,
+            )
+        )
+    finally:
+        asyncio.run(language.aclose())
+
+    print(f"evaluate {args.program}: {report.summary()}")
+    for i, tr in enumerate(report.traces, start=1):
+        mark = "pass" if tr.score >= 1.0 else "fail"
+        err = f" err={tr.error}" if tr.error else ""
+        print(f"  [{i:>3}] {mark} score={tr.score:.3f}{err}")
+    return 0
+
+
+def _run_once(args: argparse.Namespace, *, home) -> int:
+    program = _load_program(args.program)
+    raw = args.input.read_text(encoding="utf-8") if args.input else sys.stdin.read()
+    try:
+        inputs = json.loads(raw or "{}")
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"error: input is not valid JSON: {exc}\n")
+        return 2
+    if not isinstance(inputs, dict):
+        sys.stderr.write("error: input must be a JSON object\n")
+        return 2
+
+    language = _build_language(home)
+    try:
+        out = asyncio.run(
+            program.forward(
+                language,
+                {str(k): str(v) for k, v in inputs.items()},
+                provider=args.provider,
+                model=args.model,
+            )
+        )
+    finally:
+        asyncio.run(language.aclose())
+
+    print(json.dumps(out, indent=2, ensure_ascii=False))
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_program(path: Path) -> Program:
+    if not path.exists():
+        raise FileNotFoundError(f"program file not found: {path}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if "version" in data:
+        artifact = load_compiled(path)
+        return artifact.program
+    return Program.from_dict(data)
+
+
+def _load_dataset(path: Path) -> list[Example]:
+    records: list[Example] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        data = json.loads(line)
+        records.append(Example.from_dict(data))
+    if not records:
+        raise ValueError(f"dataset {path} is empty")
+    return records
+
+
+def _build_metric(program: Program, field_name: str | None) -> Metric:
+    if not field_name:
+        field_name = program.signature.output_names[0]
+    return exact_match(field_name)
+
+
+def _build_language(home) -> Language:
+    """Build a Language from the active profile's config, with a safe fallback."""
+
+    try:
+        cfg = cortex_config.load(home)
+    except (ConfigError, FileNotFoundError, OSError):
+        return Language.with_lm_studio()
+
+    provider = _provider_from_config(cfg)
+    return Language([provider])
+
+
+def _provider_from_config(cfg: Any) -> Provider:
+    model_cfg = getattr(cfg, "model", None)
+    if model_cfg is None:
+        return Provider.lm_studio()
+    base_url = getattr(model_cfg, "base_url", None) or ""
+    model_id = getattr(model_cfg, "model", None) or ""
+    api_key_env = getattr(model_cfg, "api_key_env", None) or ""
+    api_key = os.environ.get(api_key_env, "") if api_key_env else ""
+    name = getattr(model_cfg, "provider", "configured") or "configured"
+    if base_url:
+        return Provider(
+            name=name,
+            base_url=base_url,
+            api_key=api_key,
+            default_model=model_id,
+        )
+    return Provider.lm_studio(model=model_id or "google/gemma-3-4b")
+
+
+def _default_out_path(home, program_path: Path, suffix: str) -> Path:
+    base = program_path.stem
+    return home.plasticity_dir / f"{base}.{suffix}.json"
+
+
+def _print_bootstrap_report(report: BootstrapReport, out_path: Path) -> None:
+    print(f"compiled -> {out_path}")
+    print(f"  {report.summary()}")
+    for note in report.notes:
+        print(f"  note: {note}")
+
+
+def _print_gradient_report(report: GradientReport, out_path: Path) -> None:
+    print(f"optimized -> {out_path}")
+    print(f"  {report.summary()}")
+    for tr in report.steps:
+        mark = "accept" if tr.accepted else "reject"
+        print(f"  step {tr.step}: {mark} {tr.score_before:.3f} -> {tr.score_after:.3f}")
+
+
+__all__ = ["NAME", "HELP", "register", "run"]

--- a/atulya-cortex/cortex/home.py
+++ b/atulya-cortex/cortex/home.py
@@ -198,6 +198,17 @@ class CortexHome:
         return self.profile_root / "facts"
 
     @property
+    def plasticity_dir(self) -> Path:
+        """Compiled programs and optimization artifacts from `plasticity/`.
+
+        Profile-scoped because prompt-tuned programs are personality-
+        sensitive — the "work" profile should not reuse demos bootstrapped
+        against "play" examples.
+        """
+
+        return self.profile_root / "plasticity"
+
+    @property
     def consolidation_state_file(self) -> Path:
         """Cursor file: which episodes have already been distilled.
 
@@ -268,6 +279,7 @@ class CortexHome:
             self.conversations_dir,
             self.episodes_dir,
             self.facts_dir,
+            self.plasticity_dir,
             self.cache_root,
             self.llm_cache_dir,
             self.embedding_cache_dir,

--- a/atulya-cortex/plasticity/__init__.py
+++ b/atulya-cortex/plasticity/__init__.py
@@ -1,0 +1,75 @@
+"""plasticity — the cortex's optimizer / compiler for LLM programs.
+
+Neuroplasticity is the brain's ability to rewire itself through experience.
+This package is the atulya-cortex analog: it takes a small declarative LLM
+program (`Signature` + instructions + demos), a labeled dataset, and a metric,
+and returns an *improved* program by either:
+
+- **Compiling** — sampling good demonstrations from the trainset (DSPy's
+  BootstrapFewShot paradigm). When the `dspy-ai` extra is installed we drive
+  DSPy's real optimizers; otherwise we fall back to a local bootstrap loop
+  that is good enough for small local LLMs.
+
+- **Gradient-ing** — treating the natural-language *instructions* as a
+  trainable variable and stepping them via a textual critique → proposal
+  loop (TextGrad's paradigm). When `textgrad` is installed we defer to its
+  engine; otherwise we run an LLM-critic fallback that is bounded and
+  deterministic enough to use on a 4B local model.
+
+Design constraints (match the biomimetic charter):
+- Concept-per-file. Nothing in here depends on `dspy` or `textgrad` at
+  import time; those are optional runtime upgrades.
+- The only LLM surface we know about is `cortex.language.Language`. No
+  hard-coded provider names anywhere in this package.
+- Compiled programs round-trip through plain JSON so they can live under
+  `~/.atulya/cortex/plasticity/` next to the other profile state.
+
+Naming voice: `plasticity.compile`, `plasticity.gradient_step`,
+`plasticity.evaluate`. The thing we *produce* is a `Program`; the thing
+that produces it is a `Compiler` or a `TextGradient`.
+"""
+
+from __future__ import annotations
+
+from plasticity.compiler import BootstrapReport, Compiler
+from plasticity.engine import (
+    LanguageEngine,
+    build_dspy_lm,
+    build_textgrad_engine,
+)
+from plasticity.gradient import GradientReport, TextGradient
+from plasticity.metric import (
+    EvalReport,
+    Example,
+    contains,
+    evaluate,
+    exact_match,
+    llm_judge,
+    regex_match,
+)
+from plasticity.program import Demo, Program
+from plasticity.signature import Field, Signature
+from plasticity.store import load_compiled, save_compiled
+
+__all__ = [
+    "BootstrapReport",
+    "Compiler",
+    "Demo",
+    "EvalReport",
+    "Example",
+    "Field",
+    "GradientReport",
+    "LanguageEngine",
+    "Program",
+    "Signature",
+    "TextGradient",
+    "build_dspy_lm",
+    "build_textgrad_engine",
+    "contains",
+    "evaluate",
+    "exact_match",
+    "llm_judge",
+    "load_compiled",
+    "regex_match",
+    "save_compiled",
+]

--- a/atulya-cortex/plasticity/compiler.py
+++ b/atulya-cortex/plasticity/compiler.py
@@ -1,0 +1,298 @@
+"""compiler.py — demo-bootstrap compiler for Programs.
+
+Implements DSPy's `BootstrapFewShot` paradigm:
+
+  0. Start with a Program that has empty demos and the raw instructions.
+  1. Run it against each training example.
+  2. Keep the examples where the metric fires as few-shot demonstrations.
+  3. (Optional) Augment with *teacher-generated* demos: ask the LM itself
+     to produce `outputs` from `inputs`, accept only those that pass metric.
+  4. Return a new Program with the top-k demos attached.
+
+Two backends:
+
+- `backend="local"` (default) — no external deps.
+- `backend="dspy"` — drives `dspy.teleprompt.BootstrapFewShot.compile()`;
+  requires `dspy-ai` and converts the Signature/Program round-trip.
+
+Why both: DSPy's MIPROv2 / BootstrapFewShotWithRandomSearch can beat a
+handwritten bootstrap on small trainsets, but (a) dspy is an optional
+dep, and (b) the local path is enough to ship a useful first-version on
+gemma-3-4b.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Literal, Sequence
+
+from plasticity.metric import EvalReport, Example, Metric, evaluate
+from plasticity.program import Demo, Program
+
+Backend = Literal["auto", "local", "dspy"]
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BootstrapReport:
+    """What Compiler.compile() returns alongside the optimized Program."""
+
+    baseline: EvalReport | None
+    compiled: EvalReport | None
+    demos_kept: int
+    backend_used: str
+    notes: list[str] = field(default_factory=list)
+
+    def summary(self) -> str:
+        base = f"baseline={self.baseline.mean:.3f}" if self.baseline else "baseline=n/a"
+        comp = f"compiled={self.compiled.mean:.3f}" if self.compiled else "compiled=n/a"
+        return f"backend={self.backend_used} demos={self.demos_kept} {base} {comp}"
+
+
+class Compiler:
+    """Bootstrap few-shot compiler."""
+
+    def __init__(
+        self,
+        *,
+        max_demos: int = 4,
+        max_bootstraps: int = 8,
+        min_score: float = 1.0,
+        shuffle: bool = False,
+    ) -> None:
+        if max_demos < 0:
+            raise ValueError("max_demos must be non-negative")
+        if max_bootstraps < 1:
+            raise ValueError("max_bootstraps must be >= 1")
+        self.max_demos = max_demos
+        self.max_bootstraps = max_bootstraps
+        self.min_score = min_score
+        self.shuffle = shuffle
+
+    async def compile(
+        self,
+        program: Program,
+        language: Any,
+        *,
+        trainset: Sequence[Example],
+        metric: Metric,
+        valset: Sequence[Example] | None = None,
+        backend: Backend = "auto",
+        provider: str | None = None,
+        model: str | None = None,
+    ) -> tuple[Program, BootstrapReport]:
+        """Return `(compiled_program, report)`.
+
+        - `trainset` drives the demo search.
+        - `valset` (optional) drives baseline vs compiled scoring.
+        """
+
+        if not trainset:
+            raise ValueError("Compiler.compile requires a non-empty trainset")
+
+        backend_used = _resolve_backend(backend)
+        notes: list[str] = []
+
+        baseline: EvalReport | None = None
+        if valset is not None:
+            baseline = await evaluate(program, language, valset, metric, provider=provider, model=model)
+            notes.append(f"baseline over valset: {baseline.summary()}")
+
+        if backend_used == "dspy":
+            try:
+                compiled = await asyncio.to_thread(
+                    _compile_with_dspy,
+                    program,
+                    language,
+                    list(trainset),
+                    metric,
+                    self,
+                    provider,
+                    model,
+                )
+            except ImportError as exc:
+                notes.append(f"dspy unavailable ({exc}); falling back to local backend")
+                backend_used = "local"
+                compiled = await self._compile_local(
+                    program,
+                    language,
+                    trainset,
+                    metric,
+                    provider=provider,
+                    model=model,
+                    notes=notes,
+                )
+        else:
+            compiled = await self._compile_local(
+                program,
+                language,
+                trainset,
+                metric,
+                provider=provider,
+                model=model,
+                notes=notes,
+            )
+
+        compiled_report: EvalReport | None = None
+        if valset is not None:
+            compiled_report = await evaluate(compiled, language, valset, metric, provider=provider, model=model)
+            notes.append(f"compiled over valset: {compiled_report.summary()}")
+
+        report = BootstrapReport(
+            baseline=baseline,
+            compiled=compiled_report,
+            demos_kept=len(compiled.demos),
+            backend_used=backend_used,
+            notes=notes,
+        )
+        return compiled, report
+
+    async def _compile_local(
+        self,
+        program: Program,
+        language: Any,
+        trainset: Sequence[Example],
+        metric: Metric,
+        *,
+        provider: str | None,
+        model: str | None,
+        notes: list[str],
+    ) -> Program:
+        """Local bootstrap: try each trainset example up to `max_bootstraps`
+        total, keep the ones that pass `metric` as few-shot demos."""
+
+        examples = list(trainset)
+        if self.shuffle:
+            import random
+
+            random.shuffle(examples)
+
+        picked: list[tuple[float, Demo]] = []
+        attempts = 0
+        for ex in examples:
+            if len(picked) >= self.max_demos:
+                break
+            if attempts >= self.max_bootstraps:
+                break
+            attempts += 1
+            try:
+                predicted = await program.forward(
+                    language,
+                    ex.inputs,
+                    provider=provider,
+                    model=model,
+                )
+            except Exception as exc:
+                notes.append(f"local: forward failed on example: {type(exc).__name__}: {exc}")
+                continue
+            try:
+                score = float(metric(predicted, ex.outputs))
+            except Exception as exc:
+                notes.append(f"local: metric raised on example: {type(exc).__name__}: {exc}")
+                continue
+
+            # A trainset example IS ground truth — if it passes the metric,
+            # we keep its gold outputs (not the predicted ones) as the demo.
+            if score >= self.min_score:
+                demo = Demo(
+                    inputs={k: str(v) for k, v in ex.inputs.items()},
+                    outputs={k: str(v) for k, v in ex.outputs.items()},
+                )
+                picked.append((score, demo))
+
+        # Deterministic demo order: original trainset order, truncated.
+        kept = [d for _, d in picked[: self.max_demos]]
+        notes.append(f"local: kept {len(kept)}/{len(examples)} demos after {attempts} bootstraps")
+        return program.with_demos(kept)
+
+
+# ---------------------------------------------------------------------------
+# Backend resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_backend(backend: Backend) -> str:
+    if backend == "local":
+        return "local"
+    if backend == "dspy":
+        return "dspy"
+    if backend == "auto":
+        try:
+            import dspy  # type: ignore[import-not-found]  # noqa: F401
+
+            return "dspy"
+        except ImportError:
+            return "local"
+    raise ValueError(f"unknown backend {backend!r}")
+
+
+def _compile_with_dspy(
+    program: Program,
+    language: Any,
+    trainset: list[Example],
+    metric: Metric,
+    compiler: Compiler,
+    provider: str | None,
+    model: str | None,
+) -> Program:
+    """Run DSPy's BootstrapFewShot on our Program. Returns a new Program with demos."""
+
+    import dspy  # type: ignore[import-not-found]
+    from dspy.teleprompt import BootstrapFewShot  # type: ignore[import-not-found]
+
+    from plasticity.engine import build_dspy_lm
+
+    lm = build_dspy_lm(language, provider=provider, model=model)
+    dspy.configure(lm=lm)
+
+    sig = program.signature
+    input_fields = {f.name: dspy.InputField(desc=f.desc) for f in sig.inputs}
+    output_fields = {f.name: dspy.OutputField(desc=f.desc) for f in sig.outputs}
+    sig_cls = type(
+        sig.name,
+        (dspy.Signature,),
+        {
+            "__doc__": program.instructions or sig.instructions,
+            **input_fields,
+            **output_fields,
+        },
+    )
+
+    class _Module(dspy.Module):  # type: ignore[misc,no-any-unimported]
+        def __init__(self) -> None:
+            super().__init__()
+            self.predict = dspy.Predict(sig_cls)
+
+        def forward(self, **kwargs: Any) -> Any:
+            return self.predict(**kwargs)
+
+    def _dspy_metric(example: Any, prediction: Any, *_: Any, **__: Any) -> float:
+        pred = {name: getattr(prediction, name, "") for name in sig.output_names}
+        gold = {name: getattr(example, name, "") for name in sig.output_names}
+        return float(metric(pred, gold))
+
+    dspy_trainset = [dspy.Example(**ex.inputs, **ex.outputs).with_inputs(*sig.input_names) for ex in trainset]
+    tele = BootstrapFewShot(
+        metric=_dspy_metric,
+        max_bootstrapped_demos=compiler.max_demos,
+        max_rounds=1,
+    )
+    compiled_module = tele.compile(_Module(), trainset=dspy_trainset)
+
+    # Extract demos from the compiled Predict module.
+    raw_demos = getattr(compiled_module.predict, "demos", []) or []
+    demos: list[Demo] = []
+    for d in raw_demos[: compiler.max_demos]:
+        demos.append(
+            Demo(
+                inputs={n: str(getattr(d, n, "")) for n in sig.input_names},
+                outputs={n: str(getattr(d, n, "")) for n in sig.output_names},
+            )
+        )
+    return program.with_demos(demos)
+
+
+__all__ = ["BootstrapReport", "Compiler"]

--- a/atulya-cortex/plasticity/engine.py
+++ b/atulya-cortex/plasticity/engine.py
@@ -1,0 +1,262 @@
+"""engine.py — adapters that let DSPy / TextGrad drive cortex.Language.
+
+Both DSPy and TextGrad expect their own LM objects. Rather than forcing the
+rest of the cortex to know about those APIs, we expose one adapter
+(`LanguageEngine`) that wraps a `cortex.language.Language` and runs
+arbitrary chat-completions calls synchronously.
+
+- `LanguageEngine.complete(messages, ...)` returns a plain string.
+- `build_dspy_lm(language, ...)` returns a `dspy.LM`-compatible object if
+  `dspy-ai` is installed. When DSPy is missing we raise a clean
+  `ImportError` with a remediation hint — callers decide whether to fall
+  back to the local Compiler path.
+- `build_textgrad_engine(language, ...)` is the symmetric adapter for
+  TextGrad's `BlackboxLLM` / `engine.Engine` shape.
+
+All three adapters share one worker: `LanguageEngine._call_sync` which
+runs the Language coroutine on a fresh event loop when invoked from a
+synchronous context, or on the current loop when already inside one
+(via `asyncio.run_coroutine_threadsafe` on a dedicated thread).
+
+Design rationale:
+- Both DSPy and TextGrad are fundamentally synchronous. We give them a
+  blocking call site without touching the cortex async loop.
+- No environment-variable side effects: callers pass in a Language; we
+  never read `OPENAI_API_KEY` here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+# Imported lazily in build_* helpers so this module never hard-depends on
+# dspy-ai or textgrad.
+
+
+@dataclass
+class _LoopThread:
+    """One background thread hosting an asyncio loop, shared by all sync calls."""
+
+    loop: asyncio.AbstractEventLoop
+    thread: threading.Thread
+
+    def submit(self, coro: Any) -> Any:
+        fut = asyncio.run_coroutine_threadsafe(coro, self.loop)
+        return fut.result()
+
+    def stop(self) -> None:
+        if self.loop.is_running():
+            self.loop.call_soon_threadsafe(self.loop.stop)
+        self.thread.join(timeout=2.0)
+
+
+def _spawn_loop_thread() -> _LoopThread:
+    loop = asyncio.new_event_loop()
+
+    def _run() -> None:
+        asyncio.set_event_loop(loop)
+        loop.run_forever()
+
+    thread = threading.Thread(target=_run, name="plasticity-engine-loop", daemon=True)
+    thread.start()
+    return _LoopThread(loop=loop, thread=thread)
+
+
+class LanguageEngine:
+    """Synchronous façade over cortex.language.Language.
+
+    Every call is converted from async to sync. Useful for DSPy/TextGrad,
+    both of which are synchronous libraries.
+    """
+
+    def __init__(
+        self,
+        language: Any,
+        *,
+        provider: str | None = None,
+        model: str | None = None,
+        temperature: float = 0.2,
+        max_tokens: int = 512,
+    ) -> None:
+        self._language = language
+        self._provider = provider
+        self._model = model
+        self._temperature = temperature
+        self._max_tokens = max_tokens
+        self._loop: _LoopThread | None = None
+        self._lock = threading.Lock()
+
+    @property
+    def provider(self) -> str | None:
+        return self._provider
+
+    @property
+    def model(self) -> str | None:
+        return self._model
+
+    def _loop_or_start(self) -> _LoopThread:
+        with self._lock:
+            if self._loop is None:
+                self._loop = _spawn_loop_thread()
+            return self._loop
+
+    def close(self) -> None:
+        with self._lock:
+            if self._loop is not None:
+                self._loop.stop()
+                self._loop = None
+
+    def __enter__(self) -> "LanguageEngine":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    def complete(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        provider: str | None = None,
+        model: str | None = None,
+    ) -> str:
+        loop = self._loop_or_start()
+        coro = self._language.think(
+            messages,
+            provider=provider or self._provider,
+            model=model or self._model,
+            temperature=self._temperature if temperature is None else temperature,
+            max_tokens=self._max_tokens if max_tokens is None else max_tokens,
+        )
+        utterance = loop.submit(coro)
+        return utterance.text or ""
+
+    def __call__(
+        self,
+        prompt: str | list[dict[str, Any]],
+        *,
+        system: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        **_: Any,
+    ) -> str:
+        """Duck-typed entry for libraries that pass a raw string prompt."""
+
+        if isinstance(prompt, str):
+            messages: list[dict[str, Any]] = []
+            if system:
+                messages.append({"role": "system", "content": system})
+            messages.append({"role": "user", "content": prompt})
+        else:
+            messages = list(prompt)
+        return self.complete(
+            messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Optional DSPy adapter
+# ---------------------------------------------------------------------------
+
+
+def build_dspy_lm(
+    language: Any,
+    *,
+    provider: str | None = None,
+    model: str | None = None,
+    temperature: float = 0.2,
+    max_tokens: int = 512,
+) -> Any:
+    """Return a `dspy.LM`-compatible object wrapping `language`.
+
+    Raises `ImportError` if `dspy-ai` is not installed; callers should catch
+    and fall back to the local bootstrap path.
+    """
+
+    try:
+        import dspy  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - exercised only with dspy present
+        raise ImportError(
+            "dspy-ai is not installed; run `uv pip install 'atulya-cortex[optimize]'` "
+            "to enable the DSPy backend, or call Compiler.compile(..., backend='local')."
+        ) from exc
+
+    engine = LanguageEngine(
+        language,
+        provider=provider,
+        model=model,
+        temperature=temperature,
+        max_tokens=max_tokens,
+    )
+
+    class _CortexDSPyLM(dspy.LM):  # type: ignore[misc,no-any-unimported]
+        """dspy.LM subclass that routes every call through the cortex Language."""
+
+        def __init__(self) -> None:
+            super().__init__(model=model or "cortex-language")
+            self._engine = engine
+
+        def basic_request(self, prompt: str, **kwargs: Any) -> dict[str, Any]:
+            text = self._engine(prompt, **kwargs)
+            return {"choices": [{"text": text, "message": {"content": text}}]}
+
+        def __call__(self, prompt: str, **kwargs: Any) -> list[str]:
+            return [self._engine(prompt, **kwargs)]
+
+    return _CortexDSPyLM()
+
+
+# ---------------------------------------------------------------------------
+# Optional TextGrad adapter
+# ---------------------------------------------------------------------------
+
+
+def build_textgrad_engine(
+    language: Any,
+    *,
+    provider: str | None = None,
+    model: str | None = None,
+    temperature: float = 0.2,
+    max_tokens: int = 512,
+) -> Any:
+    """Return a textgrad.engine.EngineLM-compatible object wrapping `language`.
+
+    Raises `ImportError` if `textgrad` is not installed.
+    """
+
+    try:
+        import textgrad  # type: ignore[import-not-found]  # noqa: F401
+        from textgrad.engine import EngineLM  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - exercised only with textgrad present
+        raise ImportError(
+            "textgrad is not installed; run `uv pip install 'atulya-cortex[textgrad]'` "
+            "to enable the TextGrad backend, or call TextGradient.step(..., backend='local')."
+        ) from exc
+
+    engine = LanguageEngine(
+        language,
+        provider=provider,
+        model=model,
+        temperature=temperature,
+        max_tokens=max_tokens,
+    )
+
+    class _CortexTextGradEngine(EngineLM):  # type: ignore[misc,no-any-unimported]
+        def generate(self, content: str | Iterable[Any], system_prompt: str | None = None, **kwargs: Any) -> str:
+            prompt = content if isinstance(content, str) else "\n".join(str(c) for c in content)
+            return engine(prompt, system=system_prompt, **kwargs)
+
+    return _CortexTextGradEngine()
+
+
+__all__ = [
+    "LanguageEngine",
+    "build_dspy_lm",
+    "build_textgrad_engine",
+]

--- a/atulya-cortex/plasticity/gradient.py
+++ b/atulya-cortex/plasticity/gradient.py
@@ -1,0 +1,405 @@
+"""gradient.py — textual gradient descent on a Program's instructions.
+
+TextGrad's key idea: treat each string variable (prompt, instruction,
+sub-prompt) as differentiable, where the "gradient" is a natural-language
+critique produced by a strong LLM, and the "optimizer step" is another LLM
+call that rewrites the variable to reduce the loss.
+
+This module implements that loop for `Program.instructions`. One step:
+
+  1. Run the current Program on a sample of `trainset`.
+  2. For each failing example, ask the LM for a short critique of the
+     instruction text given (input, predicted, expected).
+  3. Aggregate the critiques into a single textual loss.
+  4. Ask the LM to rewrite the instructions to address the loss while
+     staying faithful to the Signature's intent.
+  5. Evaluate the proposal on `valset` (or a held-out slice of trainset).
+     If it improves, accept; otherwise keep the previous instructions.
+
+Backends:
+
+- `backend="local"` (default) — the LLM-critic loop described above.
+- `backend="textgrad"` — defers to the real `textgrad` library when
+  installed. Still uses our `LanguageEngine` for the underlying LM.
+
+`TextGradient.optimize(program, language, trainset, metric, steps=N)` runs
+N accepted or rejected proposals and returns the best Program seen.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Literal, Sequence
+
+from plasticity.metric import EvalReport, Example, Metric, evaluate
+from plasticity.program import Program
+
+Backend = Literal["auto", "local", "textgrad"]
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CRITIC_SYSTEM = (
+    "You are a careful grader of instructions for an LLM task. "
+    "Given the task instructions, one input, one expected output, and the "
+    "model's actual output, identify precisely what about the INSTRUCTIONS "
+    "caused the gap. Be terse (<= 3 bullet points). Do not rewrite the "
+    "instructions — only describe the gap."
+)
+
+DEFAULT_REWRITE_SYSTEM = (
+    "You are an expert prompt engineer. Rewrite the INSTRUCTIONS so that "
+    "the listed critiques would no longer apply, while preserving the "
+    "original task intent. Output ONLY the rewritten instructions, no "
+    "preamble, no commentary."
+)
+
+
+@dataclass
+class _StepTrace:
+    step: int
+    proposed_instructions: str
+    score_before: float
+    score_after: float
+    accepted: bool
+    critique: str = ""
+
+
+@dataclass
+class GradientReport:
+    """Result of one optimize() call."""
+
+    initial: EvalReport | None
+    final: EvalReport | None
+    best_instructions: str
+    steps: list[_StepTrace] = field(default_factory=list)
+    backend_used: str = "local"
+
+    def summary(self) -> str:
+        initial = f"initial={self.initial.mean:.3f}" if self.initial else "initial=n/a"
+        final = f"final={self.final.mean:.3f}" if self.final else "final=n/a"
+        return f"backend={self.backend_used} steps={len(self.steps)} {initial} {final}"
+
+
+class TextGradient:
+    """Textual gradient optimizer over `Program.instructions`."""
+
+    def __init__(
+        self,
+        *,
+        critic_system: str = DEFAULT_CRITIC_SYSTEM,
+        rewrite_system: str = DEFAULT_REWRITE_SYSTEM,
+        critic_temperature: float = 0.3,
+        rewrite_temperature: float = 0.5,
+        max_critique_examples: int = 3,
+    ) -> None:
+        if max_critique_examples < 1:
+            raise ValueError("max_critique_examples must be >= 1")
+        self.critic_system = critic_system
+        self.rewrite_system = rewrite_system
+        self.critic_temperature = critic_temperature
+        self.rewrite_temperature = rewrite_temperature
+        self.max_critique_examples = max_critique_examples
+
+    async def optimize(
+        self,
+        program: Program,
+        language: Any,
+        *,
+        trainset: Sequence[Example],
+        metric: Metric,
+        valset: Sequence[Example] | None = None,
+        steps: int = 3,
+        backend: Backend = "auto",
+        provider: str | None = None,
+        model: str | None = None,
+    ) -> tuple[Program, GradientReport]:
+        """Return `(best_program, report)` after up to `steps` proposals."""
+
+        if steps < 1:
+            raise ValueError("steps must be >= 1")
+        if not trainset:
+            raise ValueError("trainset must be non-empty")
+
+        backend_used = _resolve_backend(backend)
+        eval_set: Sequence[Example] = valset if valset is not None else trainset
+
+        initial_report = await evaluate(program, language, eval_set, metric, provider=provider, model=model)
+        best_program = program
+        best_mean = initial_report.mean
+        traces: list[_StepTrace] = []
+
+        for step in range(1, steps + 1):
+            if backend_used == "textgrad":
+                try:
+                    proposed = await asyncio.to_thread(
+                        _propose_with_textgrad,
+                        best_program,
+                        language,
+                        list(trainset),
+                        metric,
+                        self,
+                        provider,
+                        model,
+                    )
+                except ImportError as exc:
+                    logger.warning("textgrad unavailable (%s); falling back to local", exc)
+                    backend_used = "local"
+                    proposed, critique = await self._propose_local(
+                        best_program,
+                        language,
+                        trainset,
+                        metric,
+                        provider=provider,
+                        model=model,
+                    )
+                else:
+                    critique = "(textgrad backend)"
+            else:
+                proposed, critique = await self._propose_local(
+                    best_program,
+                    language,
+                    trainset,
+                    metric,
+                    provider=provider,
+                    model=model,
+                )
+
+            if proposed is None:
+                traces.append(
+                    _StepTrace(
+                        step=step,
+                        proposed_instructions=best_program.instructions or "",
+                        score_before=best_mean,
+                        score_after=best_mean,
+                        accepted=False,
+                        critique=critique,
+                    )
+                )
+                continue
+
+            candidate_report = await evaluate(proposed, language, eval_set, metric, provider=provider, model=model)
+            accepted = candidate_report.mean > best_mean
+            traces.append(
+                _StepTrace(
+                    step=step,
+                    proposed_instructions=proposed.instructions or "",
+                    score_before=best_mean,
+                    score_after=candidate_report.mean,
+                    accepted=accepted,
+                    critique=critique,
+                )
+            )
+            if accepted:
+                best_program = proposed
+                best_mean = candidate_report.mean
+
+        final_report = await evaluate(best_program, language, eval_set, metric, provider=provider, model=model)
+
+        return best_program, GradientReport(
+            initial=initial_report,
+            final=final_report,
+            best_instructions=best_program.instructions or best_program.signature.instructions,
+            steps=traces,
+            backend_used=backend_used,
+        )
+
+    async def _propose_local(
+        self,
+        program: Program,
+        language: Any,
+        trainset: Sequence[Example],
+        metric: Metric,
+        *,
+        provider: str | None,
+        model: str | None,
+    ) -> tuple[Program | None, str]:
+        """Produce one rewrite of `program.instructions` via an LLM critic+editor."""
+
+        critiques: list[str] = []
+        for ex in list(trainset)[: self.max_critique_examples]:
+            try:
+                predicted = await program.forward(language, ex.inputs, provider=provider, model=model)
+            except Exception as exc:
+                logger.debug("propose: forward failed: %s", exc)
+                continue
+            try:
+                score = float(metric(predicted, ex.outputs))
+            except Exception:
+                score = 0.0
+            if score >= 1.0:
+                continue
+            critique = await self._critique(
+                language,
+                program=program,
+                inputs=ex.inputs,
+                predicted=predicted,
+                expected=ex.outputs,
+                provider=provider,
+                model=model,
+            )
+            if critique.strip():
+                critiques.append(critique.strip())
+
+        if not critiques:
+            return None, "all examples passed the metric"
+
+        critique_blob = "\n".join(f"- {c}" for c in critiques)
+        proposal = await self._rewrite(
+            language,
+            instructions=program.instructions or program.signature.instructions,
+            critiques=critique_blob,
+            provider=provider,
+            model=model,
+        )
+        if not proposal.strip():
+            return None, critique_blob
+
+        return program.with_instructions(proposal.strip()), critique_blob
+
+    async def _critique(
+        self,
+        language: Any,
+        *,
+        program: Program,
+        inputs: dict[str, str],
+        predicted: dict[str, Any],
+        expected: dict[str, str],
+        provider: str | None,
+        model: str | None,
+    ) -> str:
+        body = (
+            f"INSTRUCTIONS:\n{program.instructions or program.signature.instructions}\n\n"
+            f"INPUT:\n{_dump(inputs)}\n\n"
+            f"EXPECTED:\n{_dump(expected)}\n\n"
+            f"PREDICTED:\n{_dump({k: v for k, v in predicted.items() if not k.startswith('_')})}"
+        )
+        utt = await language.think(
+            [
+                {"role": "system", "content": self.critic_system},
+                {"role": "user", "content": body},
+            ],
+            provider=provider,
+            model=model,
+            temperature=self.critic_temperature,
+            max_tokens=256,
+        )
+        return utt.text or ""
+
+    async def _rewrite(
+        self,
+        language: Any,
+        *,
+        instructions: str,
+        critiques: str,
+        provider: str | None,
+        model: str | None,
+    ) -> str:
+        body = f"INSTRUCTIONS:\n{instructions}\n\nCRITIQUES:\n{critiques}\n\nRewrite the instructions now."
+        utt = await language.think(
+            [
+                {"role": "system", "content": self.rewrite_system},
+                {"role": "user", "content": body},
+            ],
+            provider=provider,
+            model=model,
+            temperature=self.rewrite_temperature,
+            max_tokens=512,
+        )
+        return utt.text or ""
+
+
+# ---------------------------------------------------------------------------
+# Backends
+# ---------------------------------------------------------------------------
+
+
+def _resolve_backend(backend: Backend) -> str:
+    if backend == "local":
+        return "local"
+    if backend == "textgrad":
+        return "textgrad"
+    if backend == "auto":
+        try:
+            import textgrad  # type: ignore[import-not-found]  # noqa: F401
+
+            return "textgrad"
+        except ImportError:
+            return "local"
+    raise ValueError(f"unknown backend {backend!r}")
+
+
+def _propose_with_textgrad(
+    program: Program,
+    language: Any,
+    trainset: list[Example],
+    metric: Metric,
+    grad: TextGradient,
+    provider: str | None,
+    model: str | None,
+) -> Program | None:
+    """Delegate one rewrite step to the real textgrad library."""
+
+    import textgrad as tg  # type: ignore[import-not-found]
+
+    from plasticity.engine import build_textgrad_engine
+
+    engine = build_textgrad_engine(language, provider=provider, model=model)
+    tg.set_backward_engine(engine, override=True)
+
+    instructions_var = tg.Variable(
+        program.instructions or program.signature.instructions,
+        requires_grad=True,
+        role_description="instructions for the task",
+    )
+
+    # Build a simple textual loss: concatenate per-example mismatches.
+    mismatch_blobs: list[str] = []
+    for ex in trainset[: grad.max_critique_examples]:
+        try:
+            predicted = asyncio.run(program.forward(language, ex.inputs, provider=provider, model=model))
+        except Exception:
+            continue
+        if float(metric(predicted, ex.outputs)) >= 1.0:
+            continue
+        mismatch_blobs.append(
+            f"INPUT={_dump(ex.inputs)} EXPECTED={_dump(ex.outputs)} "
+            f"PREDICTED={_dump({k: v for k, v in predicted.items() if not k.startswith('_')})}"
+        )
+
+    if not mismatch_blobs:
+        return None
+
+    loss_var = tg.Variable(
+        "\n".join(mismatch_blobs),
+        requires_grad=False,
+        role_description="mismatches between expected and predicted outputs",
+    )
+    loss = tg.TextLoss(
+        tg.Variable(
+            "Identify and fix the gap in the instructions given these mismatches.",
+            requires_grad=False,
+            role_description="system prompt for computing the textual loss",
+        ),
+        engine=engine,
+    )
+    graded = loss(loss_var)
+    graded.backward()
+
+    optimizer = tg.TGD(parameters=[instructions_var])
+    optimizer.step()
+
+    return program.with_instructions(str(instructions_var.value).strip())
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _dump(d: dict[str, Any]) -> str:
+    return "\n".join(f"  {k}: {v}" for k, v in d.items())
+
+
+__all__ = ["GradientReport", "TextGradient"]

--- a/atulya-cortex/plasticity/metric.py
+++ b/atulya-cortex/plasticity/metric.py
@@ -1,0 +1,220 @@
+"""metric.py — scoring functions and evaluation runners for Programs.
+
+A metric is `Callable[[predicted: dict, expected: dict], float]` returning a
+value in `[0.0, 1.0]`. Built-ins:
+
+- `exact_match(field)` — 1.0 if the predicted field equals the expected
+  field (case-insensitive, whitespace-normalized).
+- `contains(field)` — 1.0 if the expected substring appears in the
+  predicted field.
+- `regex_match(field, pattern)` — 1.0 if the pattern matches the prediction.
+- `llm_judge(language, field, rubric)` — ask an LLM to score the prediction
+  on [0.0, 1.0] against a rubric. Used sparingly; costs one LM call per
+  example.
+
+`evaluate(program, language, examples, metric)` is the runner every compiler
+and gradient step uses. It returns an `EvalReport` with per-example traces
+so callers can introspect failures without re-running.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Mapping, Sequence
+
+from plasticity.program import Program
+
+Metric = Callable[[Mapping[str, Any], Mapping[str, Any]], float]
+
+
+@dataclass(frozen=True)
+class Example:
+    """One labeled training or eval row."""
+
+    inputs: dict[str, str]
+    outputs: dict[str, str]
+    meta: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "Example":
+        return cls(
+            inputs=dict(data.get("inputs", {})),
+            outputs=dict(data.get("outputs", {})),
+            meta=dict(data.get("meta", {})),
+        )
+
+
+@dataclass
+class _Trace:
+    example: Example
+    predicted: dict[str, Any]
+    score: float
+    error: str | None = None
+
+
+@dataclass
+class EvalReport:
+    """Result of one evaluate() run."""
+
+    scores: list[float]
+    traces: list[_Trace]
+
+    @property
+    def n(self) -> int:
+        return len(self.scores)
+
+    @property
+    def mean(self) -> float:
+        if not self.scores:
+            return 0.0
+        return sum(self.scores) / len(self.scores)
+
+    @property
+    def passes(self) -> int:
+        return sum(1 for s in self.scores if s >= 1.0)
+
+    def summary(self) -> str:
+        if not self.scores:
+            return "n=0"
+        return f"n={self.n} mean={self.mean:.3f} pass@1={self.passes}/{self.n}"
+
+
+# ---------------------------------------------------------------------------
+# Built-in metrics
+# ---------------------------------------------------------------------------
+
+
+def _norm(text: Any) -> str:
+    return re.sub(r"\s+", " ", str(text or "")).strip().casefold()
+
+
+def exact_match(field_name: str) -> Metric:
+    def _m(pred: Mapping[str, Any], gold: Mapping[str, Any]) -> float:
+        return 1.0 if _norm(pred.get(field_name)) == _norm(gold.get(field_name)) else 0.0
+
+    return _m
+
+
+def contains(field_name: str) -> Metric:
+    def _m(pred: Mapping[str, Any], gold: Mapping[str, Any]) -> float:
+        expected = _norm(gold.get(field_name))
+        got = _norm(pred.get(field_name))
+        return 1.0 if expected and expected in got else 0.0
+
+    return _m
+
+
+def regex_match(field_name: str, pattern: str, *, flags: int = re.IGNORECASE) -> Metric:
+    rx = re.compile(pattern, flags)
+
+    def _m(pred: Mapping[str, Any], gold: Mapping[str, Any]) -> float:
+        return 1.0 if rx.search(str(pred.get(field_name, ""))) else 0.0
+
+    return _m
+
+
+def llm_judge(
+    language: Any,
+    field_name: str,
+    rubric: str,
+    *,
+    provider: str | None = None,
+    temperature: float = 0.0,
+) -> Metric:
+    """Metric that delegates scoring to an LLM. 1 LM call per evaluate-row."""
+
+    prompt = (
+        "You are an exacting grader. Score the PREDICTION against the EXPECTED "
+        "value on a scale from 0.0 to 1.0 using the RUBRIC. Return ONLY a "
+        "number between 0.0 and 1.0 on the first line.\n\n"
+        "RUBRIC:\n{rubric}\n\nPREDICTION:\n{pred}\n\nEXPECTED:\n{gold}\n"
+    )
+
+    def _m(pred: Mapping[str, Any], gold: Mapping[str, Any]) -> float:
+        body = prompt.format(
+            rubric=rubric,
+            pred=pred.get(field_name, ""),
+            gold=gold.get(field_name, ""),
+        )
+
+        async def _call() -> str:
+            utt = await language.think(
+                [{"role": "user", "content": body}],
+                provider=provider,
+                temperature=temperature,
+                max_tokens=16,
+            )
+            return utt.text or ""
+
+        try:
+            text = asyncio.get_event_loop().run_until_complete(_call())
+        except RuntimeError:
+            text = asyncio.new_event_loop().run_until_complete(_call())
+
+        m = re.search(r"(\d(?:\.\d+)?)", text)
+        if not m:
+            return 0.0
+        try:
+            return max(0.0, min(1.0, float(m.group(1))))
+        except ValueError:
+            return 0.0
+
+    return _m
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+async def evaluate(
+    program: Program,
+    language: Any,
+    examples: Sequence[Example],
+    metric: Metric,
+    *,
+    provider: str | None = None,
+    model: str | None = None,
+    on_progress: Callable[[int, int], Awaitable[None]] | None = None,
+) -> EvalReport:
+    """Run `program` on each example, score with `metric`, return a report."""
+
+    scores: list[float] = []
+    traces: list[_Trace] = []
+    for i, ex in enumerate(examples):
+        err: str | None = None
+        try:
+            predicted = await program.forward(
+                language,
+                ex.inputs,
+                provider=provider,
+                model=model,
+            )
+        except Exception as exc:
+            err = f"{type(exc).__name__}: {exc}"
+            predicted = {}
+        try:
+            score = float(metric(predicted, ex.outputs))
+        except Exception as exc:
+            err = err or f"{type(exc).__name__}: {exc}"
+            score = 0.0
+        score = max(0.0, min(1.0, score))
+        scores.append(score)
+        traces.append(_Trace(example=ex, predicted=predicted, score=score, error=err))
+        if on_progress is not None:
+            await on_progress(i + 1, len(examples))
+    return EvalReport(scores=scores, traces=traces)
+
+
+__all__ = [
+    "EvalReport",
+    "Example",
+    "Metric",
+    "contains",
+    "evaluate",
+    "exact_match",
+    "llm_judge",
+    "regex_match",
+]

--- a/atulya-cortex/plasticity/program.py
+++ b/atulya-cortex/plasticity/program.py
@@ -1,0 +1,196 @@
+"""program.py — a compiled/compilable LLM program.
+
+A `Program` is `(Signature, instructions, demos)`. It renders to an
+OpenAI-style messages array, calls a `cortex.language.Language`, and parses
+the returned text back into a field-keyed dict.
+
+The prompt is deliberately simple so it works on small local LLMs
+(gemma-3-4b on LM Studio, Ollama, etc.):
+
+    <instructions>
+
+    ---
+    (demo 1)
+    Input:
+      <field_a>: ...
+      <field_b>: ...
+    Output:
+      <field_c>: ...
+
+    (demo N)
+    ...
+    ---
+    Now respond.
+    Input:
+      <field_a>: ...
+    Output:
+      <field_c>:
+
+The parser is forgiving: it extracts each output field by looking for
+"`<name>:`" at the start of a line and reading up to the next field header
+or end-of-text. Programs with one output field just take the whole reply.
+
+Naming voice: `program.forward(**inputs)` is the verb. The result is a
+dict keyed by the Signature's output names, plus a `_raw` sidechannel with
+the full LM utterance for debugging.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from plasticity.signature import Signature
+
+
+@dataclass(frozen=True)
+class Demo:
+    """One few-shot example. Values must cover every input and output name."""
+
+    inputs: dict[str, str]
+    outputs: dict[str, str]
+
+
+@dataclass
+class Program:
+    """A runnable (Signature, instructions, demos) triple."""
+
+    signature: Signature
+    instructions: str | None = None
+    demos: list[Demo] = field(default_factory=list)
+    temperature: float = 0.2
+    max_tokens: int = 512
+
+    def render_messages(self, inputs: Mapping[str, str]) -> list[dict[str, Any]]:
+        """Render a chat-completions messages array for one call."""
+
+        self.signature.validate_inputs(inputs)
+        system_text = (self.instructions or self.signature.instructions).strip()
+        user_parts: list[str] = []
+
+        if self.demos:
+            user_parts.append("Examples:\n")
+            for i, demo in enumerate(self.demos, start=1):
+                user_parts.append(f"--- example {i} ---")
+                user_parts.append("Input:")
+                for f in self.signature.inputs:
+                    user_parts.append(f"  {f.name}: {demo.inputs.get(f.name, '')}")
+                user_parts.append("Output:")
+                for f in self.signature.outputs:
+                    user_parts.append(f"  {f.name}: {demo.outputs.get(f.name, '')}")
+                user_parts.append("")
+
+        user_parts.append("Now respond.")
+        user_parts.append("Input:")
+        for f in self.signature.inputs:
+            user_parts.append(f"  {f.name}: {inputs.get(f.name, '')}")
+        user_parts.append("Output:")
+        # Nudge the model to start with the first output field.
+        if self.signature.outputs:
+            user_parts.append(f"  {self.signature.outputs[0].name}:")
+
+        user = "\n".join(user_parts)
+        return [
+            {"role": "system", "content": system_text},
+            {"role": "user", "content": user},
+        ]
+
+    def parse_response(self, text: str) -> dict[str, str]:
+        """Pull each output field out of a raw LM reply."""
+
+        names = self.signature.output_names
+        if not names:
+            return {}
+        if len(names) == 1:
+            return {names[0]: _strip_field_prefix(text, names[0]).strip()}
+
+        # Multi-field: scan the text for "  <name>:" headers in any order.
+        pattern = re.compile(
+            r"(?m)^\s*("
+            + "|".join(re.escape(n) for n in names)
+            + r")\s*:\s*(.*?)(?=^\s*(?:"
+            + "|".join(re.escape(n) for n in names)
+            + r")\s*:|\Z)",
+            re.DOTALL,
+        )
+        out: dict[str, str] = {}
+        for m in pattern.finditer(text):
+            key = m.group(1)
+            val = m.group(2).strip()
+            if key not in out:
+                out[key] = val
+        for n in names:
+            out.setdefault(n, "")
+        return out
+
+    async def forward(
+        self,
+        language: Any,
+        inputs: Mapping[str, str],
+        *,
+        provider: str | None = None,
+        model: str | None = None,
+    ) -> dict[str, Any]:
+        """Run one LLM call through `language.think` and parse the result."""
+
+        messages = self.render_messages(inputs)
+        utterance = await language.think(
+            messages,
+            provider=provider,
+            model=model,
+            temperature=self.temperature,
+            max_tokens=self.max_tokens,
+        )
+        parsed = self.parse_response(utterance.text or "")
+        parsed["_raw"] = utterance.text or ""
+        return parsed
+
+    def with_instructions(self, instructions: str) -> "Program":
+        return Program(
+            signature=self.signature,
+            instructions=instructions,
+            demos=list(self.demos),
+            temperature=self.temperature,
+            max_tokens=self.max_tokens,
+        )
+
+    def with_demos(self, demos: list[Demo]) -> "Program":
+        return Program(
+            signature=self.signature,
+            instructions=self.instructions,
+            demos=list(demos),
+            temperature=self.temperature,
+            max_tokens=self.max_tokens,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "signature": self.signature.to_dict(),
+            "instructions": self.instructions,
+            "demos": [{"inputs": d.inputs, "outputs": d.outputs} for d in self.demos],
+            "temperature": self.temperature,
+            "max_tokens": self.max_tokens,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "Program":
+        sig = Signature.from_dict(data["signature"])
+        demos = [Demo(inputs=dict(d["inputs"]), outputs=dict(d["outputs"])) for d in data.get("demos", [])]
+        return cls(
+            signature=sig,
+            instructions=data.get("instructions"),
+            demos=demos,
+            temperature=float(data.get("temperature", 0.2)),
+            max_tokens=int(data.get("max_tokens", 512)),
+        )
+
+
+def _strip_field_prefix(text: str, name: str) -> str:
+    """For single-output programs, tolerate the model starting with '<name>:'."""
+
+    m = re.match(rf"\s*{re.escape(name)}\s*:\s*(.*)$", text, re.DOTALL)
+    return m.group(1) if m else text
+
+
+__all__ = ["Demo", "Program"]

--- a/atulya-cortex/plasticity/signature.py
+++ b/atulya-cortex/plasticity/signature.py
@@ -1,0 +1,112 @@
+"""signature.py — declarative input/output contract for an LLM program.
+
+A `Signature` is a named, typed shape: what inputs a program consumes, what
+outputs it emits, and one instruction describing the task in plain English.
+
+We intentionally model this as plain dataclasses rather than a DSPy subclass
+so the rest of `plasticity/` can work without `dspy-ai` installed. The
+`to_dspy()` adapter on the `Compiler` side is the only place that imports
+DSPy.
+
+Example:
+
+    sig = Signature(
+        name="summarize",
+        instructions="Summarize the passage in one sentence.",
+        inputs=[Field("passage", "The text to summarize.")],
+        outputs=[Field("summary", "One-sentence summary.")],
+    )
+
+The rendered prompt for one call is:
+
+    {instructions}
+
+    ## {input.name}:
+    {input.value}
+
+    ## {output.name}:
+
+with a trailing newline so the model completes the final field.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Mapping
+
+
+@dataclass(frozen=True)
+class Field:
+    """One named field in a Signature. `desc` shows up in the prompt prefix."""
+
+    name: str
+    desc: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.name or not self.name.strip():
+            raise ValueError("Field.name must be a non-empty string")
+        # Field names must be identifiers so they can round-trip through JSON
+        # and through dspy.Signature when the optional DSPy backend is used.
+        if not self.name.isidentifier():
+            raise ValueError(f"Field.name {self.name!r} must be a valid Python identifier")
+
+
+@dataclass(frozen=True)
+class Signature:
+    """Declarative contract for an LLM program.
+
+    - `name` is the identifier used for storage/telemetry.
+    - `instructions` is the single system/user-prompt preamble.
+    - `inputs` and `outputs` are ordered lists of `Field`s.
+    """
+
+    name: str
+    instructions: str
+    inputs: list[Field] = field(default_factory=list)
+    outputs: list[Field] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not self.name.isidentifier():
+            raise ValueError(f"Signature.name {self.name!r} must be a valid Python identifier")
+        if not self.outputs:
+            raise ValueError("Signature requires at least one output field")
+        seen: set[str] = set()
+        for f in list(self.inputs) + list(self.outputs):
+            if f.name in seen:
+                raise ValueError(f"duplicate Signature field: {f.name!r}")
+            seen.add(f.name)
+
+    @property
+    def input_names(self) -> list[str]:
+        return [f.name for f in self.inputs]
+
+    @property
+    def output_names(self) -> list[str]:
+        return [f.name for f in self.outputs]
+
+    def validate_inputs(self, values: Mapping[str, object]) -> None:
+        missing = [n for n in self.input_names if n not in values]
+        if missing:
+            raise ValueError(f"Signature {self.name!r} missing inputs: {missing}")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "instructions": self.instructions,
+            "inputs": [{"name": f.name, "desc": f.desc} for f in self.inputs],
+            "outputs": [{"name": f.name, "desc": f.desc} for f in self.outputs],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object]) -> "Signature":
+        inputs = [Field(**f) for f in data.get("inputs", [])]  # type: ignore[arg-type]
+        outputs = [Field(**f) for f in data.get("outputs", [])]  # type: ignore[arg-type]
+        return cls(
+            name=str(data["name"]),
+            instructions=str(data.get("instructions", "")),
+            inputs=inputs,
+            outputs=outputs,
+        )
+
+
+__all__ = ["Field", "Signature"]

--- a/atulya-cortex/plasticity/store.py
+++ b/atulya-cortex/plasticity/store.py
@@ -1,0 +1,81 @@
+"""store.py — round-trip compiled Programs through a single JSON file.
+
+A compiled artifact is:
+
+    {
+      "version": 1,
+      "signature": {...},
+      "instructions": "...",
+      "demos": [...],
+      "temperature": 0.2,
+      "max_tokens": 512,
+      "meta": {"compiled_at": "ISO-8601", ...}
+    }
+
+The format is intentionally the same shape `Program.to_dict()` produces so
+that `load_compiled(path)` is just `Program.from_dict(json.load(...))`
+with a thin version check and optional meta sidechannel.
+
+Artifacts live under `<cortex_home>/plasticity/` by default; callers pass
+a path so this module has no home-dir coupling.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from plasticity.program import Program
+
+VERSION = 1
+
+
+@dataclass
+class Artifact:
+    program: Program
+    meta: dict[str, Any] = field(default_factory=dict)
+
+
+def save_compiled(
+    path: str | Path,
+    program: Program,
+    *,
+    meta: dict[str, Any] | None = None,
+) -> Path:
+    """Write the program to `path`. Creates parent dirs. Returns the path."""
+
+    dest = Path(path)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    payload: dict[str, Any] = {
+        "version": VERSION,
+        **program.to_dict(),
+        "meta": {
+            "compiled_at": datetime.now(timezone.utc).isoformat(),
+            **dict(meta or {}),
+        },
+    }
+    dest.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True),
+        encoding="utf-8",
+    )
+    return dest
+
+
+def load_compiled(path: str | Path) -> Artifact:
+    """Load the JSON at `path` and return an `Artifact`."""
+
+    src = Path(path)
+    data = json.loads(src.read_text(encoding="utf-8"))
+    version = int(data.get("version", 0))
+    if version != VERSION:
+        raise ValueError(f"unknown plasticity artifact version {version!r}; expected {VERSION}")
+    meta = dict(data.pop("meta", {}) or {})
+    data.pop("version", None)
+    program = Program.from_dict(data)
+    return Artifact(program=program, meta=meta)
+
+
+__all__ = ["Artifact", "VERSION", "load_compiled", "save_compiled"]

--- a/atulya-cortex/pyproject.toml
+++ b/atulya-cortex/pyproject.toml
@@ -23,9 +23,13 @@ dependencies = [
 telegram = ["python-telegram-bot>=21.0"]
 voice = ["pyttsx3>=2.90"]
 lmstudio = []
+optimize = ["dspy-ai>=2.4.0"]
+textgrad = ["textgrad>=0.1.4"]
 all = [
     "python-telegram-bot>=21.0",
     "pyttsx3>=2.90",
+    "dspy-ai>=2.4.0",
+    "textgrad>=0.1.4",
 ]
 
 [project.scripts]
@@ -48,6 +52,7 @@ packages = [
     "quantum",
     "brainstem",
     "dream",
+    "plasticity",
 ]
 
 [tool.hatch.build.targets.wheel.force-include]

--- a/atulya-cortex/tests/test_plasticity.py
+++ b/atulya-cortex/tests/test_plasticity.py
@@ -1,0 +1,535 @@
+"""tests/test_plasticity.py — plasticity optimizer/compiler tests.
+
+Everything in here runs against a `StubLanguage` with no external deps,
+so this test file is fully self-contained and does not require the
+optional `dspy-ai` / `textgrad` extras at test time.
+
+Coverage matrix:
+
+- `signature.py`    — Field validation, Signature.to_dict/from_dict round-trip.
+- `program.py`      — render_messages shape, parse_response (single & multi
+                      field), forward() happy path.
+- `metric.py`       — exact_match / contains / regex_match / llm_judge /
+                      evaluate() aggregation and tracing.
+- `compiler.py`     — local bootstrap keeps passing demos; dspy auto-fallback
+                      when dspy is not installed; empty trainset rejected.
+- `gradient.py`     — textgrad local backend proposes and accepts an
+                      improvement; rejects when no improvement; noop when
+                      every example already passes.
+- `store.py`        — save_compiled / load_compiled round-trip; version
+                      mismatch rejected.
+- `engine.py`       — LanguageEngine.complete() and __call__() work sync.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+
+from cortex.language import Utterance
+from plasticity import (
+    Compiler,
+    Demo,
+    Example,
+    Field,
+    LanguageEngine,
+    Program,
+    Signature,
+    TextGradient,
+    contains,
+    evaluate,
+    exact_match,
+    load_compiled,
+    regex_match,
+    save_compiled,
+)
+from plasticity.store import VERSION
+
+# ---------------------------------------------------------------------------
+# Stub Language
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StubLanguage:
+    """A deterministic Language stand-in for tests.
+
+    `responder` is called with (messages, kwargs) and returns the string to
+    put inside the Utterance. The `calls` list records every invocation so
+    tests can assert call counts.
+    """
+
+    responder: Callable[[list[dict[str, Any]], dict[str, Any]], str]
+    calls: list[dict[str, Any]] = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        self.calls = []
+
+    async def think(self, messages: list[dict[str, Any]], **kwargs: Any) -> Utterance:
+        self.calls.append({"messages": messages, "kwargs": dict(kwargs)})
+        text = self.responder(messages, kwargs)
+        return Utterance(text=text, provider="stub", model="stub", elapsed_ms=0.0)
+
+    async def aclose(self) -> None:
+        return None
+
+
+def _echo_responder(
+    text_by_message: dict[str, str] | None = None,
+) -> Callable[[list[dict[str, Any]], dict[str, Any]], str]:
+    """Return a responder that looks up a canned response by user-turn substring."""
+
+    table = dict(text_by_message or {})
+
+    def _respond(messages: list[dict[str, Any]], _kwargs: dict[str, Any]) -> str:
+        user_blob = "\n".join(m.get("content", "") for m in messages if m.get("role") == "user")
+        for key, value in table.items():
+            if key in user_blob:
+                return value
+        return ""
+
+    return _respond
+
+
+# ---------------------------------------------------------------------------
+# signature.py
+# ---------------------------------------------------------------------------
+
+
+class TestSignature:
+    def test_field_requires_identifier(self) -> None:
+        with pytest.raises(ValueError):
+            Field("has space")
+        with pytest.raises(ValueError):
+            Field("")
+
+    def test_requires_outputs(self) -> None:
+        with pytest.raises(ValueError):
+            Signature(name="s", instructions="", inputs=[Field("a")], outputs=[])
+
+    def test_detects_duplicate_fields(self) -> None:
+        with pytest.raises(ValueError):
+            Signature(
+                name="s",
+                instructions="",
+                inputs=[Field("x")],
+                outputs=[Field("x")],
+            )
+
+    def test_roundtrip_to_dict(self) -> None:
+        sig = Signature(
+            name="summarize",
+            instructions="Summarize.",
+            inputs=[Field("passage", "The input passage.")],
+            outputs=[Field("summary", "A one-sentence summary.")],
+        )
+        restored = Signature.from_dict(sig.to_dict())
+        assert restored == sig
+
+
+# ---------------------------------------------------------------------------
+# program.py
+# ---------------------------------------------------------------------------
+
+
+def _summarize_signature() -> Signature:
+    return Signature(
+        name="summarize",
+        instructions="Summarize the passage in one sentence.",
+        inputs=[Field("passage")],
+        outputs=[Field("summary")],
+    )
+
+
+def _qa_signature() -> Signature:
+    return Signature(
+        name="qa",
+        instructions="Answer the question in one short phrase.",
+        inputs=[Field("question")],
+        outputs=[Field("answer")],
+    )
+
+
+class TestProgram:
+    def test_render_messages_shape(self) -> None:
+        sig = _summarize_signature()
+        program = Program(signature=sig)
+        messages = program.render_messages({"passage": "Paris is in France."})
+        assert len(messages) == 2
+        assert messages[0]["role"] == "system"
+        assert messages[0]["content"].endswith(".")
+        user = messages[1]["content"]
+        assert "passage: Paris is in France." in user
+        assert user.strip().endswith("summary:")
+
+    def test_render_with_demos_includes_them(self) -> None:
+        sig = _summarize_signature()
+        program = Program(
+            signature=sig,
+            demos=[
+                Demo(
+                    inputs={"passage": "Rome is in Italy."},
+                    outputs={"summary": "Rome is Italian."},
+                )
+            ],
+        )
+        user = program.render_messages({"passage": "Paris is in France."})[1]["content"]
+        assert "example 1" in user
+        assert "Rome is Italian." in user
+
+    def test_validate_inputs_raises_on_missing(self) -> None:
+        sig = _summarize_signature()
+        program = Program(signature=sig)
+        with pytest.raises(ValueError):
+            program.render_messages({})
+
+    def test_parse_response_single_field(self) -> None:
+        sig = _summarize_signature()
+        program = Program(signature=sig)
+        assert program.parse_response("summary: Paris is in France.")["summary"] == "Paris is in France."
+        assert program.parse_response("A one-sentence summary.")["summary"] == "A one-sentence summary."
+
+    def test_parse_response_multi_field(self) -> None:
+        sig = Signature(
+            name="multi",
+            instructions="Return two fields.",
+            inputs=[Field("q")],
+            outputs=[Field("first"), Field("second")],
+        )
+        program = Program(signature=sig)
+        out = program.parse_response("first: alpha\nsecond: beta\n")
+        assert out == {"first": "alpha", "second": "beta"}
+
+    @pytest.mark.asyncio
+    async def test_forward_routes_through_language(self) -> None:
+        sig = _qa_signature()
+        program = Program(signature=sig)
+        lang = StubLanguage(_echo_responder({"capital of France": "answer: Paris"}))
+        out = await program.forward(lang, {"question": "What is the capital of France?"})
+        assert out["answer"] == "Paris"
+        assert out["_raw"] == "answer: Paris"
+        assert len(lang.calls) == 1
+        assert lang.calls[0]["kwargs"]["temperature"] == program.temperature
+
+    def test_with_instructions_does_not_mutate_original(self) -> None:
+        sig = _summarize_signature()
+        program = Program(signature=sig, instructions="Be terse.")
+        evolved = program.with_instructions("Be verbose.")
+        assert program.instructions == "Be terse."
+        assert evolved.instructions == "Be verbose."
+
+
+# ---------------------------------------------------------------------------
+# metric.py
+# ---------------------------------------------------------------------------
+
+
+class TestMetrics:
+    def test_exact_match_is_case_and_whitespace_insensitive(self) -> None:
+        m = exact_match("answer")
+        assert m({"answer": "Paris "}, {"answer": "  paris"}) == 1.0
+        assert m({"answer": "London"}, {"answer": "Paris"}) == 0.0
+
+    def test_contains_metric(self) -> None:
+        m = contains("answer")
+        assert m({"answer": "Paris is the capital."}, {"answer": "paris"}) == 1.0
+        assert m({"answer": "Rome."}, {"answer": "paris"}) == 0.0
+
+    def test_regex_metric(self) -> None:
+        m = regex_match("answer", r"paris")
+        assert m({"answer": "PARIS"}, {}) == 1.0
+        assert m({"answer": "Rome"}, {}) == 0.0
+
+    @pytest.mark.asyncio
+    async def test_evaluate_aggregates_and_traces(self) -> None:
+        sig = _qa_signature()
+        program = Program(signature=sig)
+        lang = StubLanguage(
+            _echo_responder(
+                {
+                    "France": "answer: Paris",
+                    "Italy": "answer: Rome",
+                    "Germany": "answer: Wrong",
+                }
+            )
+        )
+        examples = [
+            Example(inputs={"question": "Capital of France?"}, outputs={"answer": "Paris"}),
+            Example(inputs={"question": "Capital of Italy?"}, outputs={"answer": "Rome"}),
+            Example(inputs={"question": "Capital of Germany?"}, outputs={"answer": "Berlin"}),
+        ]
+        report = await evaluate(program, lang, examples, exact_match("answer"))
+        assert report.n == 3
+        assert report.passes == 2
+        assert pytest.approx(report.mean, 1e-6) == 2 / 3
+        assert [t.score for t in report.traces] == [1.0, 1.0, 0.0]
+
+    @pytest.mark.asyncio
+    async def test_evaluate_captures_forward_error(self) -> None:
+        class _Boom:
+            async def think(self, *_: Any, **__: Any) -> Any:
+                raise RuntimeError("network down")
+
+        sig = _qa_signature()
+        program = Program(signature=sig)
+        examples = [Example(inputs={"question": "q"}, outputs={"answer": "a"})]
+        report = await evaluate(program, _Boom(), examples, exact_match("answer"))
+        assert report.mean == 0.0
+        assert "network down" in (report.traces[0].error or "")
+
+
+# ---------------------------------------------------------------------------
+# compiler.py
+# ---------------------------------------------------------------------------
+
+
+class TestCompiler:
+    @pytest.mark.asyncio
+    async def test_local_backend_keeps_passing_demos(self) -> None:
+        sig = _qa_signature()
+        program = Program(signature=sig)
+        responses = {
+            "Capital of France": "answer: Paris",
+            "Capital of Italy": "answer: Rome",
+            "Capital of Germany": "answer: Wrong",
+        }
+        lang = StubLanguage(_echo_responder(responses))
+        trainset = [
+            Example(inputs={"question": "Capital of France?"}, outputs={"answer": "Paris"}),
+            Example(inputs={"question": "Capital of Italy?"}, outputs={"answer": "Rome"}),
+            Example(inputs={"question": "Capital of Germany?"}, outputs={"answer": "Berlin"}),
+        ]
+        compiler = Compiler(max_demos=5)
+        compiled, report = await compiler.compile(
+            program,
+            lang,
+            trainset=trainset,
+            metric=exact_match("answer"),
+            backend="local",
+        )
+        # The German example fails the metric, so only two demos survive.
+        assert len(compiled.demos) == 2
+        assert {d.outputs["answer"] for d in compiled.demos} == {"Paris", "Rome"}
+        assert report.backend_used == "local"
+        assert report.demos_kept == 2
+
+    @pytest.mark.asyncio
+    async def test_auto_backend_falls_back_to_local_when_dspy_missing(self) -> None:
+        sig = _qa_signature()
+        program = Program(signature=sig)
+        lang = StubLanguage(_echo_responder({"x": "answer: y"}))
+        trainset = [Example(inputs={"question": "x"}, outputs={"answer": "y"})]
+        # Regardless of whether dspy happens to be installed, the compile
+        # returns a valid Program and a populated report.
+        _, report = await Compiler().compile(
+            program,
+            lang,
+            trainset=trainset,
+            metric=exact_match("answer"),
+            backend="auto",
+        )
+        assert report.backend_used in {"local", "dspy"}
+
+    @pytest.mark.asyncio
+    async def test_empty_trainset_rejected(self) -> None:
+        sig = _qa_signature()
+        program = Program(signature=sig)
+        lang = StubLanguage(_echo_responder({}))
+        with pytest.raises(ValueError):
+            await Compiler().compile(
+                program,
+                lang,
+                trainset=[],
+                metric=exact_match("answer"),
+                backend="local",
+            )
+
+    @pytest.mark.asyncio
+    async def test_compile_records_baseline_and_compiled_over_valset(self) -> None:
+        sig = _qa_signature()
+        program = Program(signature=sig)
+        lang = StubLanguage(
+            _echo_responder(
+                {
+                    "Capital of France": "answer: Paris",
+                    "Capital of Italy": "answer: Rome",
+                }
+            )
+        )
+        trainset = [
+            Example(inputs={"question": "Capital of France?"}, outputs={"answer": "Paris"}),
+        ]
+        valset = [
+            Example(inputs={"question": "Capital of Italy?"}, outputs={"answer": "Rome"}),
+        ]
+        _, report = await Compiler(max_demos=1).compile(
+            program,
+            lang,
+            trainset=trainset,
+            metric=exact_match("answer"),
+            valset=valset,
+            backend="local",
+        )
+        assert report.baseline is not None
+        assert report.compiled is not None
+        assert report.baseline.n == 1
+        assert report.compiled.n == 1
+
+
+# ---------------------------------------------------------------------------
+# gradient.py
+# ---------------------------------------------------------------------------
+
+
+class TestTextGradient:
+    @pytest.mark.asyncio
+    async def test_local_step_accepts_when_proposal_improves_score(self) -> None:
+        sig = _qa_signature()
+        program = Program(signature=sig, instructions="Be terse.")
+
+        # The responder looks at the SYSTEM prompt: with the terse instruction
+        # we answer "Wrong"; after the rewrite uses "precise" we answer right.
+        def responder(messages: list[dict[str, Any]], kwargs: dict[str, Any]) -> str:
+            system = next((m["content"] for m in messages if m["role"] == "system"), "")
+            user = next((m["content"] for m in messages if m["role"] == "user"), "")
+            # The critic/rewrite system prompts are long; route them by prefix.
+            if system.startswith("You are a careful grader"):
+                return "- the instruction is too vague"
+            if system.startswith("You are an expert prompt engineer"):
+                return "Answer with the precise capital city."
+            if "precise capital" in system:
+                return "answer: Paris"
+            return "answer: Wrong"
+
+        lang = StubLanguage(responder)
+        trainset = [
+            Example(inputs={"question": "Capital of France?"}, outputs={"answer": "Paris"}),
+        ]
+        grad = TextGradient(max_critique_examples=1)
+        tuned, report = await grad.optimize(
+            program,
+            lang,
+            trainset=trainset,
+            metric=exact_match("answer"),
+            steps=1,
+            backend="local",
+        )
+        assert report.backend_used == "local"
+        assert report.steps[0].accepted is True
+        assert "precise" in (tuned.instructions or "").lower()
+
+    @pytest.mark.asyncio
+    async def test_optimize_is_noop_when_every_example_passes(self) -> None:
+        sig = _qa_signature()
+        program = Program(signature=sig, instructions="Answer precisely.")
+        lang = StubLanguage(_echo_responder({"France": "answer: Paris"}))
+        trainset = [
+            Example(inputs={"question": "Capital of France?"}, outputs={"answer": "Paris"}),
+        ]
+        tuned, report = await TextGradient().optimize(
+            program,
+            lang,
+            trainset=trainset,
+            metric=exact_match("answer"),
+            steps=2,
+            backend="local",
+        )
+        # No critique produced because everything already passes.
+        assert tuned.instructions == program.instructions
+        assert all(not s.accepted for s in report.steps)
+
+    @pytest.mark.asyncio
+    async def test_rejects_proposal_that_doesnt_improve(self) -> None:
+        sig = _qa_signature()
+        program = Program(signature=sig, instructions="Be terse.")
+
+        def responder(messages: list[dict[str, Any]], _kwargs: dict[str, Any]) -> str:
+            system = next((m["content"] for m in messages if m["role"] == "system"), "")
+            if system.startswith("You are a careful grader"):
+                return "- the instruction is too vague"
+            if system.startswith("You are an expert prompt engineer"):
+                return "Still useless instructions."
+            return "answer: Wrong"
+
+        lang = StubLanguage(responder)
+        trainset = [Example(inputs={"question": "q"}, outputs={"answer": "Paris"})]
+        tuned, report = await TextGradient(max_critique_examples=1).optimize(
+            program,
+            lang,
+            trainset=trainset,
+            metric=exact_match("answer"),
+            steps=1,
+            backend="local",
+        )
+        assert tuned.instructions == program.instructions
+        assert report.steps[0].accepted is False
+
+
+# ---------------------------------------------------------------------------
+# store.py
+# ---------------------------------------------------------------------------
+
+
+class TestStore:
+    def test_roundtrip_preserves_program(self, tmp_path: Path) -> None:
+        sig = _qa_signature()
+        program = Program(
+            signature=sig,
+            instructions="Precise.",
+            demos=[Demo(inputs={"question": "x"}, outputs={"answer": "y"})],
+            temperature=0.1,
+            max_tokens=256,
+        )
+        path = save_compiled(tmp_path / "qa.json", program, meta={"note": "test"})
+        artifact = load_compiled(path)
+        assert artifact.program.signature == program.signature
+        assert artifact.program.instructions == program.instructions
+        assert artifact.program.demos == program.demos
+        assert artifact.program.temperature == pytest.approx(0.1)
+        assert artifact.meta["note"] == "test"
+        assert "compiled_at" in artifact.meta
+
+    def test_version_mismatch_rejected(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad.json"
+        path.write_text(json.dumps({"version": VERSION + 99}), encoding="utf-8")
+        with pytest.raises(ValueError):
+            load_compiled(path)
+
+
+# ---------------------------------------------------------------------------
+# engine.py
+# ---------------------------------------------------------------------------
+
+
+class TestLanguageEngine:
+    def test_complete_is_sync(self) -> None:
+        lang = StubLanguage(_echo_responder({"hello": "world"}))
+        with LanguageEngine(lang) as engine:
+            text = engine.complete(
+                [{"role": "user", "content": "hello"}],
+                temperature=0.0,
+                max_tokens=10,
+            )
+        assert text == "world"
+        assert lang.calls[0]["kwargs"]["temperature"] == 0.0
+        assert lang.calls[0]["kwargs"]["max_tokens"] == 10
+
+    def test_callable_wraps_prompt_string(self) -> None:
+        lang = StubLanguage(_echo_responder({"please": "ok"}))
+        with LanguageEngine(lang) as engine:
+            text = engine("please")
+        assert text == "ok"
+
+    def test_close_is_idempotent(self) -> None:
+        lang = StubLanguage(_echo_responder({"x": "y"}))
+        engine = LanguageEngine(lang)
+        engine.close()
+        engine.close()  # must not raise
+        # We can still re-use the engine after a close() because submit()
+        # re-spawns the loop thread.
+        asyncio.run(lang.aclose())

--- a/uv.lock
+++ b/uv.lock
@@ -345,6 +345,18 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncer"
+version = "0.0.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/67/7ea59c3e69eaeee42e7fc91a5be67ca5849c8979acac2b920249760c6af2/asyncer-0.0.8.tar.gz", hash = "sha256:a589d980f57e20efb07ed91d0dbe67f1d2fd343e7142c66d3a099f05c620739c", size = 18217, upload-time = "2024-08-24T23:15:36.449Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/04/15b6ca6b7842eda2748bda0a0af73f2d054e9344320f8bba01f994294bcb/asyncer-0.0.8-py3-none-any.whl", hash = "sha256:5920d48fc99c8f8f0f1576e1882f5022885589c5fcbc46ce4224ec3e53776eeb", size = 9209, upload-time = "2024-08-24T23:15:35.317Z" },
+]
+
+[[package]]
 name = "asyncpg"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -647,11 +659,19 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
+    { name = "dspy-ai" },
     { name = "python-telegram-bot" },
     { name = "pyttsx3" },
+    { name = "textgrad" },
+]
+optimize = [
+    { name = "dspy-ai" },
 ]
 telegram = [
     { name = "python-telegram-bot" },
+]
+textgrad = [
+    { name = "textgrad" },
 ]
 voice = [
     { name = "pyttsx3" },
@@ -668,6 +688,8 @@ dev = [
 requires-dist = [
     { name = "atulya", editable = "atulya-bridge" },
     { name = "diskcache", specifier = ">=5.6.3" },
+    { name = "dspy-ai", marker = "extra == 'all'", specifier = ">=2.4.0" },
+    { name = "dspy-ai", marker = "extra == 'optimize'", specifier = ">=2.4.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "prompt-toolkit", specifier = ">=3.0.43" },
     { name = "pydantic", specifier = ">=2.6.0" },
@@ -677,9 +699,11 @@ requires-dist = [
     { name = "pyttsx3", marker = "extra == 'all'", specifier = ">=2.90" },
     { name = "pyttsx3", marker = "extra == 'voice'", specifier = ">=2.90" },
     { name = "rich", specifier = ">=13.0.0" },
+    { name = "textgrad", marker = "extra == 'all'", specifier = ">=0.1.4" },
+    { name = "textgrad", marker = "extra == 'textgrad'", specifier = ">=0.1.4" },
     { name = "tomli-w", specifier = ">=1.0.0" },
 ]
-provides-extras = ["telegram", "voice", "lmstudio", "all"]
+provides-extras = ["telegram", "voice", "lmstudio", "optimize", "textgrad", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1065,6 +1089,18 @@ wheels = [
 ]
 
 [[package]]
+name = "colorlog"
+version = "6.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/61/f083b5ac52e505dfc1c624eafbf8c7589a0d7f32daa398d2e7590efa5fda/colorlog-6.10.1.tar.gz", hash = "sha256:eb4ae5cb65fe7fec7773c2306061a8e63e02efc2c72eba9d27b0fa23c94f1321", size = 17162, upload-time = "2025-10-16T16:14:11.978Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl", hash = "sha256:2d7e8348291948af66122cff006c9f8da6255d224e7cf8e37d8de2df3bad8c9c", size = 11743, upload-time = "2025-10-16T16:14:10.512Z" },
+]
+
+[[package]]
 name = "comtypes"
 version = "1.4.16"
 source = { registry = "https://pypi.org/simple" }
@@ -1148,6 +1184,31 @@ wheels = [
 ]
 
 [[package]]
+name = "datasets"
+version = "4.8.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dill" },
+    { name = "filelock" },
+    { name = "fsspec", extra = ["http"] },
+    { name = "httpx" },
+    { name = "huggingface-hub" },
+    { name = "multiprocess" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "pyarrow" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "tqdm" },
+    { name = "xxhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/22/73e46ac7a8c25e7ef0b3bd6f10da3465021d90219a32eb0b4d2afea4c56e/datasets-4.8.4.tar.gz", hash = "sha256:a1429ed853275ce7943a01c6d2e25475b4501eb758934362106a280470df3a52", size = 604382, upload-time = "2026-03-23T14:21:17.987Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/e5/247d094108e42ac26363ab8dc57f168840cf7c05774b40ffeb0d78868fcc/datasets-4.8.4-py3-none-any.whl", hash = "sha256:cdc8bee4698e549d78bf1fed6aea2eebc760b22b084f07e6fc020c6577a6ce6d", size = 526991, upload-time = "2026-03-23T14:21:15.89Z" },
+]
+
+[[package]]
 name = "dateparser"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1169,6 +1230,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
+name = "dill"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
 ]
 
 [[package]]
@@ -1228,6 +1298,47 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d9/02/111134bfeb6e6c7ac4c74594e39a59f6c0195dc4846afbeac3cba60f1927/docutils-0.22.3.tar.gz", hash = "sha256:21486ae730e4ca9f622677b1412b879af1791efcfba517e4c6f60be543fc8cdd", size = 2290153, upload-time = "2025-11-06T02:35:55.655Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/a8/c6a4b901d17399c77cd81fb001ce8961e9f5e04d3daf27e8925cb012e163/docutils-0.22.3-py3-none-any.whl", hash = "sha256:bd772e4aca73aff037958d44f2be5229ded4c09927fcf8690c577b66234d6ceb", size = 633032, upload-time = "2025-11-06T02:35:52.391Z" },
+]
+
+[[package]]
+name = "dspy"
+version = "3.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "asyncer" },
+    { name = "cachetools" },
+    { name = "cloudpickle" },
+    { name = "diskcache" },
+    { name = "gepa" },
+    { name = "json-repair" },
+    { name = "litellm" },
+    { name = "numpy" },
+    { name = "openai" },
+    { name = "optuna" },
+    { name = "orjson" },
+    { name = "pydantic" },
+    { name = "regex" },
+    { name = "requests" },
+    { name = "tenacity" },
+    { name = "tqdm" },
+    { name = "xxhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/06/1b693d28a08e7a8b9ea17641259a73760de111ce0187cdcf030148a42ec1/dspy-3.1.3.tar.gz", hash = "sha256:e2fd9edc8678e0abcacd5d7b901f37b84a9f48a3c50718fc7fee95a492796019", size = 261178, upload-time = "2026-02-05T16:24:18.489Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/83/2432c2f987e738e4c15dfa3497daa5811a145facf4525bebcb9d240736db/dspy-3.1.3-py3-none-any.whl", hash = "sha256:26f983372ebb284324cc2162458f7bce509ef5ef7b48be4c9f490fa06ea73e37", size = 312353, upload-time = "2026-02-05T16:24:16.753Z" },
+]
+
+[[package]]
+name = "dspy-ai"
+version = "3.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dspy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bf/56/fc26b51a10b360255e957e4af95286ec0677707e0bfed29dad1a0cc49d45/dspy_ai-3.1.3.tar.gz", hash = "sha256:ad414555bcd5a57b6d135736876256cfeb93ddf735455d173e5f3b875c1c00d0", size = 1113, upload-time = "2026-02-05T16:24:27.096Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/d9/96671e96cae106ad7ecf4809be906925cd67401e7eee31b4f28bb4641fa4/dspy_ai-3.1.3-py3-none-any.whl", hash = "sha256:128ab0c0aef1386491a704f16823faf93da165674f9cf1fa7165f4f2d1ec9e67", size = 1096, upload-time = "2026-02-05T16:24:26.363Z" },
 ]
 
 [[package]]
@@ -1655,6 +1766,36 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/02/a6b21098b1d5d6249b7c5ab69dde30108a71e4e819d4a9778f1de1d5b70d/fsspec-2025.10.0-py3-none-any.whl", hash = "sha256:7c7712353ae7d875407f97715f0e1ffcc21e33d5b24556cb1e090ae9409ec61d", size = 200966, upload-time = "2025-10-30T14:58:42.53Z" },
 ]
 
+[package.optional-dependencies]
+http = [
+    { name = "aiohttp" },
+]
+
+[[package]]
+name = "gdown"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "filelock" },
+    { name = "requests", extra = ["socks"] },
+    { name = "tqdm" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/01/9e0280ba321f73295374765dc3c0b1e03058188a592a48a321376f9eb092/gdown-6.0.0.tar.gz", hash = "sha256:1f1f735a174ef3599fca95786aafac1219b9d85d4c729ccb95e674996c47fd44", size = 262729, upload-time = "2026-04-12T06:37:40.182Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/fd/a382bb6684b1fdbe5cd19aa980a04a67f6c91efd0e1e627f93614fe2d24e/gdown-6.0.0-py3-none-any.whl", hash = "sha256:c82d39a6b09ed7778012515c2fa4ab4dc36d7789300cd0b16b87d3a3e4a09955", size = 18243, upload-time = "2026-04-12T06:37:38.209Z" },
+]
+
+[[package]]
+name = "gepa"
+version = "0.0.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/98/b8f1ccc8cc2a319f21433df45bcec8a8f7903ee08aacd0acfdc475f47c05/gepa-0.0.26.tar.gz", hash = "sha256:0119ca8022e93b6236bc154a57bb910bdb117485dc067d77777933dd3e9e9ad8", size = 141776, upload-time = "2026-01-24T18:11:18.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/6e/f1141b76398026ef77f0d52a17b37d26ceb7cd320e0ad3a72c59fe00b983/gepa-0.0.26-py3-none-any.whl", hash = "sha256:331e40d8693a4192de2eb3b2b4df10d410ead49173f748d50c32a035cf746e63", size = 139666, upload-time = "2026-01-24T18:11:16.836Z" },
+]
+
 [[package]]
 name = "gitdb"
 version = "4.0.12"
@@ -1727,6 +1868,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e5/7b/adfd75544c415c487b33061fe7ae526165241c1ea133f9a9125a56b39fd8/googleapis_common_protos-1.72.0.tar.gz", hash = "sha256:e55a601c1b32b52d7a3e65f43563e2aa61bcd737998ee672ac9b951cd49319f5", size = 147433, upload-time = "2025-11-06T18:29:24.087Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/ab/09169d5a4612a5f92490806649ac8d41e3ec9129c636754575b3553f4ea4/googleapis_common_protos-1.72.0-py3-none-any.whl", hash = "sha256:4299c5a82d5ae1a9702ada957347726b167f9f8d1fc352477702a1e851ff4038", size = 297515, upload-time = "2025-11-06T18:29:13.14Z" },
+]
+
+[[package]]
+name = "graphviz"
+version = "0.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/b3/3ac91e9be6b761a4b30d66ff165e54439dcd48b83f4e20d644867215f6ca/graphviz-0.21.tar.gz", hash = "sha256:20743e7183be82aaaa8ad6c93f8893c923bd6658a04c32ee115edb3c8a835f78", size = 200434, upload-time = "2025-06-15T09:35:05.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/4c/e0ce1ef95d4000ebc1c11801f9b944fa5910ecc15b5e351865763d8657f8/graphviz-0.21-py3-none-any.whl", hash = "sha256:54f33de9f4f911d7e84e4191749cac8cc5653f815b06738c54db9a15ab8b1e42", size = 47300, upload-time = "2025-06-15T09:35:04.433Z" },
 ]
 
 [[package]]
@@ -2109,6 +2259,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/5d/447af5ea094b9e4c4054f82e223ada074c552335b9b4b2d14bd9b35a67c4/joblib-1.5.2.tar.gz", hash = "sha256:3faa5c39054b2f03ca547da9b2f52fde67c06240c31853f306aea97f13647b55", size = 331077, upload-time = "2025-08-27T12:15:46.575Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/e8/685f47e0d754320684db4425a0967f7d3fa70126bffd76110b7009a0090f/joblib-1.5.2-py3-none-any.whl", hash = "sha256:4e1f0bdbb987e6d843c70cf43714cb276623def372df3c22fe5266b2670bc241", size = 308396, upload-time = "2025-08-27T12:15:45.188Z" },
+]
+
+[[package]]
+name = "json-repair"
+version = "0.59.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/41/4ae9c6e711647a41b4e0c04bce815113ce9c0286eff6dc6fb86979b2fb9f/json_repair-0.59.4.tar.gz", hash = "sha256:559ca1828f6f566530663cd96d64bee29f8282b9d2ff0e661e05fa87b4171ab3", size = 47624, upload-time = "2026-04-15T06:48:40.776Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/c4/ec3068436d2275731539b7a43fbc947f502bc3fe149856a5d00368c7b087/json_repair-0.59.4-py3-none-any.whl", hash = "sha256:46052e646bc0b0c39db672ebbf732f774f3c1a5bde81a54f0b0e19d3af4f45cd", size = 46697, upload-time = "2026-04-15T06:48:39.61Z" },
 ]
 
 [[package]]
@@ -2794,6 +2953,26 @@ wheels = [
 ]
 
 [[package]]
+name = "multiprocess"
+version = "0.70.19"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dill" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/f2/e783ac7f2aeeed14e9e12801f22529cc7e6b7ab80928d6dcce4e9f00922d/multiprocess-0.70.19.tar.gz", hash = "sha256:952021e0e6c55a4a9fe4cd787895b86e239a40e76802a789d6305398d3975897", size = 2079989, upload-time = "2026-01-19T06:47:39.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/aa/714635c727dbfc251139226fa4eaf1b07f00dc12d9cd2eb25f931adaf873/multiprocess-0.70.19-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:1bbf1b69af1cf64cd05f65337d9215b88079ec819cd0ea7bac4dab84e162efe7", size = 144743, upload-time = "2026-01-19T06:47:24.562Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e1/155f6abf5e6b5d9cef29b6d0167c180846157a4aca9b9bee1a217f67c959/multiprocess-0.70.19-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:5be9ec7f0c1c49a4f4a6fd20d5dda4aeabc2d39a50f4ad53720f1cd02b3a7c2e", size = 144738, upload-time = "2026-01-19T06:47:26.636Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cb/f421c2869d75750a4f32301cc20c4b63fab6376e9a75c8e5e655bdeb3d9b/multiprocess-0.70.19-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:1c3dce098845a0db43b32a0b76a228ca059a668071cfeaa0f40c36c0b1585d45", size = 144741, upload-time = "2026-01-19T06:47:27.985Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/45/8004d1e6b9185c1a444d6b55ac5682acf9d98035e54386d967366035a03a/multiprocess-0.70.19-py310-none-any.whl", hash = "sha256:97404393419dcb2a8385910864eedf47a3cadf82c66345b44f036420eb0b5d87", size = 134948, upload-time = "2026-01-19T06:47:32.325Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c2/dec9722dc3474c164a0b6bcd9a7ed7da542c98af8cabce05374abab35edd/multiprocess-0.70.19-py311-none-any.whl", hash = "sha256:928851ae7973aea4ce0eaf330bbdafb2e01398a91518d5c8818802845564f45c", size = 144457, upload-time = "2026-01-19T06:47:33.711Z" },
+    { url = "https://files.pythonhosted.org/packages/71/70/38998b950a97ea279e6bd657575d22d1a2047256caf707d9a10fbce4f065/multiprocess-0.70.19-py312-none-any.whl", hash = "sha256:3a56c0e85dd5025161bac5ce138dcac1e49174c7d8e74596537e729fd5c53c28", size = 150281, upload-time = "2026-01-19T06:47:35.037Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/74/d2c27e03cb84251dfe7249b8e82923643c6d48fa4883b9476b025e7dc7eb/multiprocess-0.70.19-py313-none-any.whl", hash = "sha256:8d5eb4ec5017ba2fab4e34a747c6d2c2b6fecfe9e7236e77988db91580ada952", size = 156414, upload-time = "2026-01-19T06:47:35.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/61/af9115673a5870fd885247e2f1b68c4f1197737da315b520a91c757a861a/multiprocess-0.70.19-py314-none-any.whl", hash = "sha256:e8cc7fbdff15c0613f0a1f1f8744bef961b0a164c0ca29bdff53e9d2d93c5e5f", size = 160318, upload-time = "2026-01-19T06:47:37.497Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/82/69e539c4c2027f1e1697e09aaa2449243085a0edf81ae2c6341e84d769b6/multiprocess-0.70.19-py39-none-any.whl", hash = "sha256:0d4b4397ed669d371c81dcd1ef33fd384a44d6c3de1bd0ca7ac06d837720d3c5", size = 133477, upload-time = "2026-01-19T06:47:38.619Z" },
+]
+
+[[package]]
 name = "narwhals"
 version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3321,6 +3500,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/50/fc/c47bb04a1d8a941a4061307e1eddfa331ed4d0ab13d8a9781e6db256940a/opentelemetry_util_http-0.60b1.tar.gz", hash = "sha256:0d97152ca8c8a41ced7172d29d3622a219317f74ae6bb3027cfbdcf22c3cc0d6", size = 11053, upload-time = "2025-12-11T13:37:25.115Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/5c/d3f1733665f7cd582ef0842fb1d2ed0bc1fba10875160593342d22bba375/opentelemetry_util_http-0.60b1-py3-none-any.whl", hash = "sha256:66381ba28550c91bee14dcba8979ace443444af1ed609226634596b4b0faf199", size = 8947, upload-time = "2025-12-11T13:36:37.151Z" },
+]
+
+[[package]]
+name = "optuna"
+version = "4.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "alembic" },
+    { name = "colorlog" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "sqlalchemy" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bf/9b/62f120fb2ecbc4338bee70c5a3671c8e561714f3aa1a046b897ff142050e/optuna-4.8.0.tar.gz", hash = "sha256:6f7043e9f8ecb5e607af86a7eb00fb5ec2be26c3b08c201209a73d36aff37a38", size = 482603, upload-time = "2026-03-16T04:59:58.659Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/24/7c731839566d30dc70556d9824ef17692d896c15e3df627bce8c16f753e1/optuna-4.8.0-py3-none-any.whl", hash = "sha256:c57a7682679c36bfc9bca0da430698179e513874074b71bebedb0334964ab930", size = 419456, upload-time = "2026-03-16T04:59:56.977Z" },
 ]
 
 [[package]]
@@ -6968,6 +7165,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pysocks"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429, upload-time = "2019-09-20T02:07:35.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725, upload-time = "2019-09-20T02:06:22.938Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -7347,6 +7553,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[package.optional-dependencies]
+socks = [
+    { name = "pysocks" },
 ]
 
 [[package]]
@@ -8007,6 +8218,29 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8b/02/ef62dec9e4f804189c44df23f0b86897c738d38e9c48282fcd410308632f/testcontainers-4.14.1.tar.gz", hash = "sha256:316f1bb178d829c003acd650233e3ff3c59a833a08d8661c074f58a4fbd42a64", size = 80148, upload-time = "2026-01-31T23:13:46.915Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/31/5e7b23f9e43ff7fd46d243808d70c5e8daf3bc08ecf5a7fb84d5e38f7603/testcontainers-4.14.1-py3-none-any.whl", hash = "sha256:03dfef4797b31c82e7b762a454b6afec61a2a512ad54af47ab41e4fa5415f891", size = 125640, upload-time = "2026-01-31T23:13:45.464Z" },
+]
+
+[[package]]
+name = "textgrad"
+version = "0.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "datasets" },
+    { name = "diskcache" },
+    { name = "gdown" },
+    { name = "graphviz" },
+    { name = "httpx" },
+    { name = "litellm" },
+    { name = "openai" },
+    { name = "pandas" },
+    { name = "pillow" },
+    { name = "platformdirs" },
+    { name = "python-dotenv" },
+    { name = "tenacity" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/05/2978c1feae998d8d25b2deabdd09f5aa42bed3db22ef860ccf55319b85b8/textgrad-0.1.8.tar.gz", hash = "sha256:96b32ab9f737a81152479fa7b8fc6bef98433f472d28ecd942ee3d9d190f6175", size = 72246, upload-time = "2025-03-26T17:08:11.029Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/96/7c2e8b9b8c06f0566ca09e38e936105a550f8fb22924ff6aa2f967742060/textgrad-0.1.8-py3-none-any.whl", hash = "sha256:f252572bd25cd7cbdc4528024f70895b3e92328932e37e576691d20eead0a63a", size = 79578, upload-time = "2025-03-26T17:08:09.849Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds **`plasticity/`**, a new biomimetic organ in `atulya-cortex` that compiles and optimizes LLM programs against labeled data:

- **Compiler** — DSPy-style few-shot bootstrap (`dspy-ai` when installed, local fallback otherwise).
- **Text gradient** — TextGrad-style instruction optimization (`textgrad` when installed, local critic+rewriter otherwise).
- **CLI** — `atulya-cortex plasticity {compile,optimize,evaluate,run}`.
- **Home** — `CortexHome.plasticity_dir` (profile-scoped) for compiled JSON artifacts.

Optional extras: `optimize`, `textgrad`, both included in `all`.

## Verification

- `uv run --package atulya-cortex pytest tests/ -q -o addopts=""` → 398 passed, 2 skipped
- `uv run --package atulya-cortex ruff check .` → clean
- Pre-commit `lint.sh` passed on commit

## Commit

`3d20863` — `[feature] ~ plasticity: DSPy + TextGrad optimizer/compiler for LLM programs`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new `plasticity` package plus a new CLI surface and optional heavy ML dependencies (`dspy-ai`, `textgrad`), which may affect packaging/runtime behavior and LLM call patterns despite being largely isolated and optional.
> 
> **Overview**
> Adds a new **`plasticity/`** subsystem for training-like workflows over declarative LLM programs: a `Program`/`Signature` model, dataset `Example`s, metrics, an `evaluate()` runner, and JSON artifact storage (`save_compiled`/`load_compiled`).
> 
> Exposes this via a new `atulya-cortex plasticity` CLI with `compile`, `optimize`, `evaluate`, and `run` actions, including profile-configured provider/model selection and default outputs under the new profile-scoped `CortexHome.plasticity_dir`.
> 
> Implements two optimization paths with safe fallbacks: few-shot demo bootstrapping via `Compiler` (`dspy` backend when available, otherwise local), and instruction tuning via `TextGradient` (`textgrad` backend when available, otherwise a local critique→rewrite loop), and adds comprehensive unit tests for the new package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d2086350f522c32debe199474552013649295fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->