### PR TITLE
Global self-healing and adaptive plasticity prompt memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ target/
 
 # Temp files
 .tmp/
+.tmp_attention_network
 
 
 

--- a/atulya-cortex/cortex/_runtime.py
+++ b/atulya-cortex/cortex/_runtime.py
@@ -24,6 +24,8 @@ from cortex.episodes import EpisodeStore
 from cortex.language import Language, Provider
 from cortex.peer_memory import PeerMemoryBridge, build_peer_memory_bridge
 from cortex.personality import Personality
+from cortex.plasticity_prompt_memory import PlasticityPromptMemory, PlasticityPromptSettings
+from cortex.self_healing import SelfHealingEngine, SelfHealingSettings
 from cortex.semantic_facts import FactStore
 from cortex.skills import Skills
 from cortex.tool_protocol import ToolSpec
@@ -137,7 +139,10 @@ def build_cortex_from_config(
         auto_consolidate = _auto_consolidate
 
     peer_bridge: PeerMemoryBridge | None = build_peer_memory_bridge(
-        config, cortex_profile=home.profile_name
+        config,
+        cortex_profile=home.profile_name,
+        whatsapp_mental_models_dir=home.whatsapp_mental_models_dir,
+        whatsapp_memory_raw_dir=home.whatsapp_memory_raw_dir,
     )
     recall_fn = None
     if peer_bridge is not None:
@@ -146,6 +151,34 @@ def build_cortex_from_config(
             return await peer_bridge.cortex_recall(query, kind, bank)
 
         recall_fn = _recall_fn
+
+    self_healing = SelfHealingEngine(
+        SelfHealingSettings(
+            enabled=config.self_healing.enabled,
+            max_retries=config.self_healing.max_retries,
+            min_reply_chars=config.self_healing.min_reply_chars,
+            judge_enabled=config.self_healing.judge_enabled,
+            judge_provider=config.self_healing.judge_provider,
+            judge_model=config.self_healing.judge_model,
+            fallback_text=config.self_healing.fallback_text,
+            telemetry_enabled=config.self_healing.telemetry_enabled,
+        ),
+        telemetry_file=home.logs_dir / "self-healing.jsonl",
+    )
+    plasticity = PlasticityPromptMemory(
+        home.plasticity_dir / "prompt-memory.json",
+        PlasticityPromptSettings(
+            enabled=config.plasticity.enabled,
+            per_user_enabled=config.plasticity.per_user_enabled,
+            system_enabled=config.plasticity.system_enabled,
+            max_directives=config.plasticity.max_directives,
+            time_context_enabled=config.plasticity.time_context_enabled,
+            distill_enabled=config.plasticity.distill_enabled,
+            distill_min_updates=config.plasticity.distill_min_updates,
+            distill_cooldown_s=config.plasticity.distill_cooldown_s,
+            distill_max_versions=config.plasticity.distill_max_versions,
+        ),
+    )
 
     return Cortex(
         name=config.general.name,
@@ -175,6 +208,8 @@ def build_cortex_from_config(
         peer_memory=peer_bridge,
         cortex_profile=home.profile_name,
         peer_bank_channels=frozenset(config.memory.peer_banks_channels),
+        self_healing=self_healing,
+        plasticity=plasticity,
     )
 
 

--- a/atulya-cortex/cortex/cli_commands/peer_bank.py
+++ b/atulya-cortex/cortex/cli_commands/peer_bank.py
@@ -1,0 +1,298 @@
+"""peer_bank — inspect and manage per-peer bank mental models.
+
+This command is for operator workflows where each remote contact maps to a
+stable bank id (``cortex_<profile>_<peer>``) and the bank's mental model is
+used as top-level prompt context during channel conversations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+from cortex import config as config_module
+from cortex.peer_banks import peer_bank_id
+from cortex.peer_mental_model_store import BankEntitySnapshot, MentalModelSnapshot, sync_peer_mental_model_file
+
+NAME = "peer-bank"
+HELP = "Manage per-peer bank mental models."
+
+
+def register(subparsers, common_parents) -> None:
+    parser = subparsers.add_parser(
+        NAME,
+        help=HELP,
+        parents=list(common_parents),
+        description="Inspect/set mental models for a peer-specific bank.",
+    )
+    sub = parser.add_subparsers(dest="peer_bank_command", metavar="<action>")
+
+    p_resolve = sub.add_parser("resolve", help="Resolve bank_id from peer key.")
+    p_resolve.add_argument("peer", help="Peer key or channel key, e.g. 255@lid or whatsapp:255@lid")
+    p_resolve.set_defaults(_peer_bank_run=_run_resolve)
+
+    p_get = sub.add_parser("get", help="Show bank and matching mental models.")
+    p_get.add_argument("peer", help="Peer key or channel key, e.g. whatsapp:255@lid")
+    p_get.add_argument("--name", default="", help="Filter by mental model name.")
+    p_get.add_argument("--json", action="store_true", help="Emit JSON.")
+    p_get.set_defaults(_peer_bank_run=_run_get)
+
+    p_set = sub.add_parser("set", help="Create/update one named mental model for this peer bank.")
+    p_set.add_argument("peer", help="Peer key or channel key, e.g. whatsapp:255@lid")
+    p_set.add_argument("--name", default="peer_profile", help="Mental model name.")
+    p_set.add_argument("--content", required=True, help="Mental model content.")
+    p_set.add_argument("--json", action="store_true", help="Emit JSON.")
+    p_set.set_defaults(_peer_bank_run=_run_set)
+
+    parser.set_defaults(_run=run)
+
+
+def run(args: argparse.Namespace, *, home) -> int:
+    handler = getattr(args, "_peer_bank_run", None)
+    if handler is None:
+        return _run_resolve(args, home=home)
+    return handler(args, home=home)
+
+
+def _run_resolve(args: argparse.Namespace, *, home) -> int:
+    peer = _peer_only(args.peer)
+    bank_id = peer_bank_id(home.profile_name, peer)
+    print(bank_id)
+    return 0
+
+
+def _run_get(args: argparse.Namespace, *, home) -> int:
+    cfg = _load_config_or_die(home)
+    if cfg is None:
+        return 2
+    peer = _peer_only(args.peer)
+    bank_id = peer_bank_id(home.profile_name, peer)
+    emb = _embedded_for_config(cfg, home.profile_name)
+    try:
+        _ensure_bank(emb, bank_id)
+        models = _models_for_bank(emb, bank_id)
+        if args.name:
+            models = [m for m in models if _pick(m, "name") == args.name]
+        _sync_whatsapp_file(home, peer, bank_id, models)
+        payload = {
+            "peer": peer,
+            "bank_id": bank_id,
+            "mental_models": [{"id": _pick(m, "id"), "name": _pick(m, "name"), "content": _pick(m, "content")} for m in models],
+        }
+        if args.json:
+            print(json.dumps(payload, indent=2))
+            return 0
+        print(f"peer:    {peer}")
+        print(f"bank_id: {bank_id}")
+        if not models:
+            print("(no mental models)")
+            return 0
+        for m in payload["mental_models"]:
+            preview = m["content"] if len(m["content"]) <= 180 else m["content"][:177] + "..."
+            print(f"- {m['name']} ({m['id']})")
+            print(f"  {preview}")
+        return 0
+    finally:
+        _close_safely(emb)
+
+
+def _run_set(args: argparse.Namespace, *, home) -> int:
+    cfg = _load_config_or_die(home)
+    if cfg is None:
+        return 2
+    peer = _peer_only(args.peer)
+    bank_id = peer_bank_id(home.profile_name, peer)
+    emb = _embedded_for_config(cfg, home.profile_name)
+    try:
+        _ensure_bank(emb, bank_id)
+        target_name = (args.name or "peer_profile").strip() or "peer_profile"
+        content = str(args.content or "").strip()
+        if not content:
+            print("error: --content cannot be empty", file=sys.stderr)
+            return 2
+
+        existing = None
+        for m in _models_for_bank(emb, bank_id):
+            if _pick(m, "name") == target_name:
+                existing = m
+                break
+        if existing is not None:
+            model_id = _pick(existing, "id")
+            out = _update_mental_model_compat(
+                emb,
+                bank_id=bank_id,
+                mental_model_id=model_id,
+                name=target_name,
+                content=content,
+            )
+            status = "updated"
+        else:
+            out = _create_mental_model_compat(
+                emb,
+                bank_id=bank_id,
+                name=target_name,
+                content=content,
+            )
+            status = "created"
+        _sync_whatsapp_file(home, peer, bank_id, _models_for_bank(emb, bank_id))
+
+        payload = {
+            "status": status,
+            "peer": peer,
+            "bank_id": bank_id,
+            "name": target_name,
+            "mental_model_id": _pick(out, "id"),
+        }
+        if args.json:
+            print(json.dumps(payload, indent=2))
+        else:
+            print(f"{status} {target_name} for {peer} in {bank_id}")
+        return 0
+    finally:
+        _close_safely(emb)
+
+
+def _peer_only(peer_or_channel: str) -> str:
+    value = (peer_or_channel or "").strip()
+    if not value:
+        raise ValueError("peer is required")
+    if ":" in value:
+        _, tail = value.split(":", 1)
+        return tail.strip()
+    return value
+
+
+def _load_config_or_die(home):
+    try:
+        return config_module.load(home)
+    except config_module.ConfigError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return None
+
+
+def _embedded_for_config(config, cortex_profile: str):
+    from atulya import AtulyaClient, AtulyaEmbedded
+
+    backend = (getattr(config.memory, "peer_banks_backend", "embedded") or "embedded").strip().lower()
+    if backend == "api":
+        import os
+
+        api_key_env = (getattr(config.memory, "api_key_env", "") or "").strip()
+        api_key = os.environ.get(api_key_env, "") if api_key_env else ""
+        return AtulyaClient(base_url=config.memory.api_url, api_key=api_key or None)
+    ep = (getattr(config.memory, "embed_profile", "") or "").strip() or cortex_profile
+    return AtulyaEmbedded(profile=ep)
+
+
+def _ensure_bank(emb: Any, bank_id: str) -> None:
+    try:
+        emb.banks.create(
+            bank_id=bank_id,
+            mission="Store conversational turns and durable facts about this person.",
+        )
+    except Exception:
+        # Bank creation is idempotent in spirit; ignore "already exists" style failures.
+        pass
+
+
+def _models_for_bank(emb: Any, bank_id: str) -> list[Any]:
+    listed = emb.mental_models.list(bank_id)
+    return list(getattr(listed, "items", []) or [])
+
+
+def _pick(obj: Any, key: str) -> str:
+    if isinstance(obj, dict):
+        value = obj.get(key, "")
+    else:
+        value = getattr(obj, key, "")
+    return str(value or "").strip()
+
+
+def _close_safely(emb: Any) -> None:
+    try:
+        emb.close()
+    except Exception:
+        pass
+
+
+def _create_mental_model_compat(emb: Any, *, bank_id: str, name: str, content: str) -> Any:
+    try:
+        return emb.mental_models.create(bank_id, name=name, content=content)
+    except TypeError:
+        # Newer atulya-api shape uses source_query instead of content.
+        try:
+            return emb.client.create_mental_model(
+                bank_id=bank_id,
+                name=name,
+                source_query=content,
+            )
+        except TypeError:
+            return emb.client.create_mental_model(
+                bank_id=bank_id,
+                name=name,
+                content=content,
+            )
+
+
+def _update_mental_model_compat(
+    emb: Any,
+    *,
+    bank_id: str,
+    mental_model_id: str,
+    name: str,
+    content: str,
+) -> Any:
+    try:
+        return emb.mental_models.update(
+            bank_id,
+            mental_model_id,
+            name=name,
+            content=content,
+        )
+    except TypeError:
+        try:
+            return emb.client.update_mental_model(
+                bank_id=bank_id,
+                mental_model_id=mental_model_id,
+                name=name,
+                source_query=content,
+            )
+        except TypeError:
+            return emb.client.update_mental_model(
+                bank_id=bank_id,
+                mental_model_id=mental_model_id,
+                name=name,
+                content=content,
+            )
+
+
+def _sync_whatsapp_file(home, peer: str, bank_id: str, models: list[Any]) -> None:
+    snapshots: list[MentalModelSnapshot] = []
+    for m in models:
+        snapshots.append(
+            MentalModelSnapshot(
+                model_id=_pick(m, "id") or _pick(m, "name") or "mental-model",
+                name=_pick(m, "name") or "mental-model",
+                content=_pick(m, "content"),
+            )
+        )
+    listed = _models_and_entities_for_file(models)
+    sync_peer_mental_model_file(
+        directory=home.whatsapp_mental_models_dir,
+        peer_key=peer,
+        bank_id=bank_id,
+        models=snapshots,
+        entities=listed,
+    )
+
+
+def _models_and_entities_for_file(models: list[Any]) -> list[BankEntitySnapshot]:
+    # CLI path doesn't fetch memory entities from DB to keep this command fast.
+    # It still writes an entities section (possibly empty) so file schema is stable.
+    return []
+
+
+__all__ = ["NAME", "HELP", "register", "run"]
+

--- a/atulya-cortex/cortex/cli_commands/whatsapp.py
+++ b/atulya-cortex/cortex/cli_commands/whatsapp.py
@@ -29,9 +29,11 @@ import argparse
 import asyncio
 import logging
 import os
+import random
 import shutil
 import signal
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -47,6 +49,11 @@ DEFAULT_BRIDGE_PORT = 7732
 DEFAULT_BRIDGE_DIR = "scripts/whatsapp-bridge"
 
 logger = logging.getLogger(__name__)
+EMPTY_REPLY_SELF_HEAL_RETRIES = 1
+
+
+def _ts_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
 
 
 # ---------------------------------------------------------------------------
@@ -351,6 +358,19 @@ async def _full_loop(
 
     language = None if args.echo else build_language_from_config(config)
     cortex = build_cortex_from_config(home, config, language=language)
+    peer_memory = getattr(cortex, "_peer_memory", None)
+
+    if peer_memory is not None:
+        probe_bank = f"{config.memory.bank_id}__peer_memory_probe"
+        ok, detail = await peer_memory.startup_healthcheck(probe_bank_id=probe_bank)
+        if ok:
+            print(f"[peer-memory] {detail}")
+        else:
+            print(f"[peer-memory] WARNING: {detail}", file=sys.stderr)
+            print(
+                "             recall/retain may degrade to best-effort; check memory.api_url/backend/auth settings.",
+                file=sys.stderr,
+            )
 
     # Pre-flight: confirm the LLM endpoint is actually reachable BEFORE we
     # wait silently on inbound messages. A misconfigured base_url here used
@@ -370,9 +390,21 @@ async def _full_loop(
         # Visibility on outbound: same shape as `[recv]` on inbound, so the
         # operator can read the conversation top-to-bottom in the loop log.
         preview = text if len(text) < 80 else text[:77] + "..."
-        sys.stderr.write(f"[send] {channel}: {preview}\n")
-        sys.stderr.flush()
-        await ear.send(target, text)
+        max_attempts = 3
+        last_err: Exception | None = None
+        for attempt in range(1, max_attempts + 1):
+            try:
+                sys.stderr.write(f"[{_ts_utc()}] [send] {channel}: {preview}\n")
+                sys.stderr.flush()
+                await ear.send(target, text)
+                return
+            except Exception as exc:
+                last_err = exc
+                if attempt >= max_attempts:
+                    break
+                # Small jittered backoff to survive short bridge hiccups.
+                await asyncio.sleep(0.15 * attempt + random.random() * 0.1)
+        raise RuntimeError(f"egress failed after {max_attempts} attempts: {last_err}")
 
     reply = Reply({"whatsapp": egress})
 
@@ -395,20 +427,50 @@ async def _full_loop(
         # prompt before calling the LLM, then appends both halves of the
         # new exchange after the call. This is what stops the bot from
         # answering "what's my name?" with a hallucinated guess.
-        try:
-            return await cortex.reflect(stim, reflex=reflex, peer_key=stim.sender)
-        except Exception as exc:
-            logger.exception("cortex.reflect crashed on %s", stim.channel)
-            from cortex.bus import Action, Intent
+        from cortex.bus import Action, Intent
 
-            return Intent(
-                action=Action(
-                    kind="reply",
-                    payload={"text": f"sorry — my brain hit an error ({type(exc).__name__}). I'll be back soon."},
-                ),
-                channel=stim.channel,
-                sender=stim.sender,
-            )
+        retry_stim = stim
+        attempts = 1 + max(0, int(EMPTY_REPLY_SELF_HEAL_RETRIES))
+        for attempt in range(attempts):
+            try:
+                intent = await cortex.reflect(retry_stim, reflex=reflex, peer_key=retry_stim.sender)
+            except Exception as exc:
+                logger.exception("cortex.reflect crashed on %s", stim.channel)
+                return Intent(
+                    action=Action(
+                        kind="reply",
+                        payload={"text": f"sorry — my brain hit an error ({type(exc).__name__}). I'll be back soon."},
+                    ),
+                    channel=stim.channel,
+                    sender=stim.sender,
+                )
+
+            if getattr(intent.action, "kind", "") != "reply":
+                return intent
+            reply_text = str(intent.action.payload.get("text", "")).strip()
+            if reply_text:
+                return intent
+            if attempt + 1 >= attempts:
+                break
+
+            logger.warning("empty reply generated for %s; retrying once with self-heal prompt", stim.channel)
+            original_text = (stim.text or "").strip()
+            retry_text = (
+                f"{original_text}\n\n"
+                "[self-heal: previous draft was empty. Produce one clear and useful reply now.]"
+            ).strip()
+            retry_raw = dict(getattr(stim, "raw", {}) or {})
+            retry_raw["_self_heal_retry"] = attempt + 1
+            retry_stim = stim.model_copy(update={"text": retry_text, "raw": retry_raw})
+
+        return Intent(
+            action=Action(
+                kind="reply",
+                payload={"text": "I had a blank-thought glitch. Please send that once more and I will answer properly."},
+            ),
+            channel=stim.channel,
+            sender=stim.sender,
+        )
 
     async def reply_motor(intent):
         return await reply.act(intent)
@@ -447,6 +509,11 @@ async def _full_loop(
         pump_task.cancel()
         stop_task.cancel()
         await ear.tune_out()
+        if peer_memory is not None:
+            try:
+                await peer_memory.aclose()
+            except Exception:
+                logger.warning("peer memory close failed", exc_info=True)
         if language is not None:
             await language.aclose()
     print("WhatsApp loop stopped.")
@@ -489,10 +556,21 @@ async def _pump_stimuli(ear, router) -> None:
         # the cortex is dead, the bridge is wedged, or the contact is just
         # blocked by DMPairing.
         preview = stim.text if len(stim.text) < 80 else stim.text[:77] + "..."
-        sys.stderr.write(f"[recv] {stim.channel}: {preview}\n")
+        sys.stderr.write(f"[{_ts_utc()}] [recv] {stim.channel}: {preview}\n")
         sys.stderr.flush()
         try:
-            await router.route(stim)
+            outcome = await router.route(stim)
+            motor_result = getattr(outcome, "motor_result", None)
+            if motor_result is not None and hasattr(motor_result, "ok") and not bool(getattr(motor_result, "ok", True)):
+                detail = getattr(motor_result, "detail", "") or "unknown motor failure"
+                sys.stderr.write(f"[{_ts_utc()}] [send-error] {stim.channel}: {detail}\n")
+                sys.stderr.flush()
+            intent = getattr(outcome, "intent", None)
+            if intent is not None and getattr(intent.action, "kind", "") == "reply":
+                reply_text = str(intent.action.payload.get("text", "")).strip()
+                if not reply_text:
+                    sys.stderr.write(f"[{_ts_utc()}] [reply-empty] {stim.channel}: cortex returned empty reply text\n")
+                    sys.stderr.flush()
         except Exception:
             logger.exception("router crashed on stimulus from %s; continuing", stim.channel)
 

--- a/atulya-cortex/cortex/config.py
+++ b/atulya-cortex/cortex/config.py
@@ -79,7 +79,7 @@ class ModelConfig(_Section):
 
 class MemoryConfig(_Section):
     bank_id: str = "atulya-cortex"
-    api_url: str = "http://localhost:8000"
+    api_url: str = "http://localhost:8888"
     api_key_env: str = "ATULYA_API_KEY"
     # When true, each remote peer gets a dedicated atulya-embed bank id
     # ``cortex_<profile>_<peer>`` (see ``cortex.peer_banks.peer_bank_id``).
@@ -90,6 +90,10 @@ class MemoryConfig(_Section):
     peer_banks_channels: list[str] = Field(default_factory=lambda: ["whatsapp", "telegram"])
     # atulya-embed daemon profile name. Empty uses the active cortex profile name.
     embed_profile: str = ""
+    # Backend for per-peer banks:
+    # - embedded: use AtulyaEmbedded daemon/profile (often :8984)
+    # - api: use configured atulya-api URL (often :8888, aligned with UI)
+    peer_banks_backend: str = "embedded"
     recall_top_k: int = Field(default=4, ge=1, le=64)
     recall_kinds: list[str] = Field(default_factory=lambda: ["episodic", "semantic"])
     # Working memory bounds. These guard small local models from blowing
@@ -130,6 +134,14 @@ class MemoryConfig(_Section):
             if s and s not in out:
                 out.append(s)
         return out
+
+    @field_validator("peer_banks_backend")
+    @classmethod
+    def _normalize_peer_banks_backend(cls, value: str) -> str:
+        backend = (value or "").strip().lower()
+        if backend not in {"embedded", "api"}:
+            raise ValueError(f"peer_banks_backend must be embedded|api, got {value!r}")
+        return backend
 
 
 class TelegramConfig(_Section):
@@ -220,6 +232,29 @@ class ToolsConfig(_Section):
     fs_write_enabled: bool = True
 
 
+class SelfHealingConfig(_Section):
+    enabled: bool = True
+    max_retries: int = Field(default=1, ge=0, le=5)
+    min_reply_chars: int = Field(default=8, ge=0, le=256)
+    judge_enabled: bool = True
+    judge_provider: str = ""
+    judge_model: str = ""
+    fallback_text: str = "I hit a response glitch. Please retry that once."
+    telemetry_enabled: bool = True
+
+
+class PlasticityConfig(_Section):
+    enabled: bool = True
+    per_user_enabled: bool = True
+    system_enabled: bool = True
+    max_directives: int = Field(default=6, ge=1, le=64)
+    time_context_enabled: bool = True
+    distill_enabled: bool = True
+    distill_min_updates: int = Field(default=5, ge=1, le=500)
+    distill_cooldown_s: float = Field(default=300.0, ge=1.0, le=86400.0)
+    distill_max_versions: int = Field(default=16, ge=1, le=256)
+
+
 class CortexConfig(BaseModel):
     """Top-level config. Every section is required to be present after merge
     with template defaults; that guarantees `cfg.model.provider` is always
@@ -238,6 +273,8 @@ class CortexConfig(BaseModel):
     dream: DreamConfig = Field(default_factory=DreamConfig)
     logging: LoggingConfig = Field(default_factory=LoggingConfig)
     tools: ToolsConfig = Field(default_factory=ToolsConfig)
+    self_healing: SelfHealingConfig = Field(default_factory=SelfHealingConfig)
+    plasticity: PlasticityConfig = Field(default_factory=PlasticityConfig)
 
 
 # ---------------------------------------------------------------------------
@@ -418,6 +455,8 @@ __all__ = [
     "GeneralConfig",
     "LoggingConfig",
     "MemoryConfig",
+    "PlasticityConfig",
+    "SelfHealingConfig",
     "ModelConfig",
     "SkillsConfig",
     "TelegramConfig",

--- a/atulya-cortex/cortex/cortex.py
+++ b/atulya-cortex/cortex/cortex.py
@@ -20,6 +20,7 @@ Naming voice: `Cortex.reflect` is the load-bearing verb.
 from __future__ import annotations
 
 import re
+from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable, Sequence
 
 from cortex.affect import Affect, score_text
@@ -38,7 +39,9 @@ from cortex.episodes import EpisodeStore, render_episode_block
 from cortex.peer_banks import peer_bank_id
 from cortex.peer_memory import PeerMemoryBridge
 from cortex.personality import Personality
+from cortex.plasticity_prompt_memory import PlasticityPromptMemory
 from cortex.semantic_facts import FactStore
+from cortex.self_healing import SelfHealingEngine
 from cortex.skills import Skills, render_skills_block
 from cortex.tool_protocol import (
     ToolCall,
@@ -122,6 +125,8 @@ class Cortex:
         peer_memory: PeerMemoryBridge | None = None,
         cortex_profile: str = "default",
         peer_bank_channels: frozenset[str] | None = None,
+        self_healing: SelfHealingEngine | None = None,
+        plasticity: PlasticityPromptMemory | None = None,
     ) -> None:
         self.name = name
         self._language = language
@@ -184,6 +189,8 @@ class Cortex:
         self._peer_memory = peer_memory
         self._cortex_profile = (cortex_profile or "default").strip() or "default"
         self._peer_bank_channels = peer_bank_channels or frozenset()
+        self._self_healing = self_healing
+        self._plasticity = plasticity
 
     @property
     def has_language(self) -> bool:
@@ -219,6 +226,7 @@ class Cortex:
 
         # Per-peer atulya-embed bank (optional): stable id from cortex profile + peer.
         memory_bank_id: str | None = None
+        bank_mental_model_prompt = ""
         if (
             peer_key
             and self._peer_memory is not None
@@ -227,6 +235,11 @@ class Cortex:
         ):
             memory_bank_id = peer_bank_id(self._cortex_profile, peer_key)
             await self._peer_memory.ensure_bank(memory_bank_id)
+            bank_mental_model_prompt = await self._peer_memory.bank_mental_model_prompt(
+                memory_bank_id,
+                peer_key=peer_key,
+                channel_root=_channel_root(stimulus.channel),
+            )
 
         # Working memory: per (channel, peer) JSONL transcript.
         conv = None
@@ -248,6 +261,7 @@ class Cortex:
                 thought,
                 history=history,
                 peer_key=peer_key,
+                bank_mental_model_prompt=bank_mental_model_prompt,
             )
         else:
             reply_text = await self._think(
@@ -255,8 +269,23 @@ class Cortex:
                 sandboxed=sandboxed,
                 history=history,
                 peer_key=peer_key,
+                bank_mental_model_prompt=bank_mental_model_prompt,
             )
             deliberation_log = []
+
+        if self._self_healing is not None:
+            healed = await self._self_healing.heal_reply(
+                language=self._language,
+                stimulus_text=stimulus.text or "",
+                draft_reply=reply_text,
+                provider=self._provider,
+                model=self._model,
+                temperature=self._temperature,
+                max_tokens=self._max_tokens,
+                channel=stimulus.channel,
+                peer_key=peer_key,
+            )
+            reply_text = healed.text
 
         # Persist *after* the LLM call so a partial failure (timeout,
         # disconnect) doesn't leave us with a one-sided history that
@@ -321,6 +350,29 @@ class Cortex:
                 # call reflect() via asyncio.run). Skip silently.
                 pass
 
+        if self._plasticity is not None and (user_text or reply_text):
+            try:
+                self._plasticity.record_turn(peer_key=peer_key, user_text=user_text, assistant_text=reply_text)
+            except Exception:
+                pass
+            if self._plasticity.distill_enabled and self._language is not None:
+                try:
+                    import asyncio as _asyncio
+
+                    _asyncio.create_task(
+                        self._plasticity.distill_if_due(
+                            language=self._language,
+                            provider=self._provider,
+                            model=self._model,
+                            temperature=self._temperature,
+                            max_tokens=self._max_tokens,
+                            peer_key=peer_key,
+                        ),
+                        name=f"cortex-plasticity-distill-{_channel_root(stimulus.channel)}",
+                    )
+                except RuntimeError:
+                    pass
+
         # Vector substrate: retain this turn into the peer's bank (async).
         if self._peer_memory is not None and memory_bank_id and (user_text or reply_text):
             try:
@@ -382,12 +434,14 @@ class Cortex:
         sandboxed: bool,
         history: list[Any] | None = None,
         peer_key: str | None = None,
+        bank_mental_model_prompt: str = "",
     ) -> str:
         messages = self._build_messages(
             thought,
             sandboxed=sandboxed,
             history=history or [],
             peer_key=peer_key,
+            bank_mental_model_prompt=bank_mental_model_prompt,
         )
         utt: Utterance = await self._language.think(  # type: ignore[union-attr]
             messages,
@@ -404,6 +458,7 @@ class Cortex:
         *,
         history: list[Any] | None,
         peer_key: str | None,
+        bank_mental_model_prompt: str = "",
     ) -> tuple[str, list[dict[str, Any]]]:
         """Closed-loop deliberation arc — think, act, observe, repeat.
 
@@ -424,6 +479,7 @@ class Cortex:
             sandboxed=False,
             history=history or [],
             peer_key=peer_key,
+            bank_mental_model_prompt=bank_mental_model_prompt,
             include_tools=True,
         )
         log: list[dict[str, Any]] = []
@@ -532,10 +588,21 @@ class Cortex:
         sandboxed: bool,
         history: list[Any] | None = None,
         peer_key: str | None = None,
+        bank_mental_model_prompt: str = "",
         include_tools: bool = False,
     ) -> list[dict[str, Any]]:
         system_parts: list[str] = []
+        if bank_mental_model_prompt:
+            system_parts.append(bank_mental_model_prompt)
         system_parts.append(thought.persona or self._personality.system_prompt_block())
+        if self._plasticity is None or self._plasticity.time_context_enabled:
+            time_note = self._time_context_note(thought.stimulus)
+            if time_note:
+                system_parts.append(time_note)
+        if self._plasticity is not None:
+            adaptive = self._plasticity.prompt_block(peer_key=peer_key)
+            if adaptive:
+                system_parts.append(adaptive)
 
         # Per-peer identity hint: persona files almost always anchor on
         # "the operator" (the human running the brain locally). When the
@@ -617,6 +684,20 @@ class Cortex:
             f"({peer_key}). They are NOT {self._operator_label}. Do not assume their "
             "name, location, or relationship to you unless they tell you in this "
             "conversation."
+        )
+
+    def _time_context_note(self, stimulus: Stimulus) -> str:
+        now = datetime.now(timezone.utc)
+        received = stimulus.received_at
+        if received.tzinfo is None:
+            received = received.replace(tzinfo=timezone.utc)
+        delta_s = max(0.0, (now - received).total_seconds())
+        return (
+            "Time context:\n"
+            f"- now_utc: {now.isoformat()}\n"
+            f"- weekday_utc: {now.strftime('%A')}\n"
+            f"- message_received_utc: {received.isoformat()}\n"
+            f"- receive_to_reflect_seconds: {delta_s:.3f}"
         )
 
     def _echo_intent(self, stimulus: Stimulus) -> Intent:

--- a/atulya-cortex/cortex/home.py
+++ b/atulya-cortex/cortex/home.py
@@ -241,6 +241,14 @@ class CortexHome:
         return self.whatsapp_dir / "session"
 
     @property
+    def whatsapp_mental_models_dir(self) -> Path:
+        return self.whatsapp_dir / "mental-models"
+
+    @property
+    def whatsapp_memory_raw_dir(self) -> Path:
+        return self.whatsapp_dir / "memory-raw"
+
+    @property
     def logs_dir(self) -> Path:
         return self.root / "logs"
 
@@ -285,6 +293,8 @@ class CortexHome:
             self.embedding_cache_dir,
             self.whatsapp_dir,
             self.whatsapp_session_dir,
+            self.whatsapp_mental_models_dir,
+            self.whatsapp_memory_raw_dir,
             self.logs_dir,
             self.profiles_root,
         )

--- a/atulya-cortex/cortex/peer_memory.py
+++ b/atulya-cortex/cortex/peer_memory.py
@@ -7,11 +7,22 @@ then retains and recalls against that bank.
 
 from __future__ import annotations
 
+import asyncio
+import json
 import logging
+import time
+from datetime import UTC, datetime
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
+import os
 
 from cortex.bus import MemoryKind, Recollection, Stimulus
+from cortex.peer_mental_model_store import (
+    BankEntitySnapshot,
+    MentalModelSnapshot,
+    sync_peer_mental_model_file,
+)
 from memory.hippocampus import Hippocampus
 from memory.recall import Recall
 
@@ -26,7 +37,11 @@ class PeerMemoryBridge:
     hippocampus: Hippocampus
     recall: Recall
     recall_top_k: int
+    whatsapp_mental_models_dir: Path | None = None
+    whatsapp_memory_raw_dir: Path | None = None
     _ensured: set[str] = field(default_factory=set)
+    _mental_prompt_cache: dict[str, tuple[float, str]] = field(default_factory=dict)
+    _mental_prompt_ttl_s: float = 0.0
 
     async def ensure_bank(self, bank_id: str) -> None:
         """Create the bank if we have not seen this id in-process yet."""
@@ -43,6 +58,162 @@ class PeerMemoryBridge:
             return
         self._ensured.add(bank_id)
 
+    async def bank_mental_model_prompt(
+        self,
+        bank_id: str,
+        *,
+        peer_key: str = "",
+        channel_root: str = "",
+        max_models: int = 3,
+        max_chars_per_model: int = 600,
+        max_entities: int = 88,
+    ) -> str:
+        """Render a compact prompt block from this bank's mental models.
+
+        This is used as peer-specific steering context in `Cortex._build_messages`.
+        Empty string means "no bank-level mental model available".
+        """
+
+        cache_key = f"{channel_root}:{peer_key}:{bank_id}"
+        cached = self._mental_prompt_cache.get(cache_key)
+        now = time.monotonic()
+        if cached is not None and (now - cached[0]) <= self._mental_prompt_ttl_s:
+            return cached[1]
+
+        await self.ensure_bank(bank_id)
+        try:
+            items = await self._list_mental_models(bank_id)
+        except Exception as exc:
+            logger.warning("peer mental-model list failed bank=%s: %s", bank_id, exc)
+            self._mental_prompt_cache[cache_key] = (now, "")
+            return ""
+
+        lines: list[str] = []
+        snapshots: list[MentalModelSnapshot] = []
+        for item in items[: max(0, int(max_models))]:
+            model_id = _pick(item, "id")
+            name = _pick(item, "name") or "mental-model"
+            content = _pick(item, "content")
+            if not content and model_id:
+                try:
+                    detail = await self._get_mental_model(bank_id, model_id)
+                    content = _pick(detail, "content")
+                except Exception:
+                    content = ""
+            text = _squash_whitespace(str(content or ""))
+            if not text:
+                continue
+            snapshots.append(MentalModelSnapshot(model_id=model_id or name, name=name, content=text))
+            if len(text) > max_chars_per_model:
+                text = text[: max_chars_per_model - 3].rstrip() + "..."
+            lines.append(f"- {name}: {text}")
+
+        top_entities = await self._top_used_bank_entities(bank_id, limit=max_entities)
+        entity_lines: list[str] = []
+        for entity in top_entities:
+            snippet = entity.text
+            if len(snippet) > 180:
+                snippet = snippet[:177].rstrip() + "..."
+            entity_lines.append(f"- [{entity.kind}] {entity.entity_id}: {snippet}")
+
+        if (
+            self.whatsapp_mental_models_dir is not None
+            and peer_key
+            and channel_root == "whatsapp"
+        ):
+            try:
+                sync_peer_mental_model_file(
+                    directory=self.whatsapp_mental_models_dir,
+                    peer_key=peer_key,
+                    bank_id=bank_id,
+                    models=snapshots,
+                    entities=top_entities,
+                )
+            except Exception as exc:
+                logger.warning("peer mental-model file sync failed bank=%s peer=%s: %s", bank_id, peer_key, exc)
+
+        if not lines and not entity_lines:
+            self._mental_prompt_cache[cache_key] = (now, "")
+            return ""
+
+        sections: list[str] = []
+        if lines:
+            sections.append(
+                "Peer bank mental model (primary guidance for this peer):\n"
+                + "\n".join(lines)
+                + "\nTreat this as the default stance for this peer unless the user explicitly overrides it."
+            )
+        if entity_lines:
+            sections.append(
+                "Top used entities from this peer bank (capped at 88):\n"
+                + "\n".join(entity_lines[:max_entities])
+            )
+        block = "\n\n".join(sections)
+        self._mental_prompt_cache[cache_key] = (now, block)
+        return block
+
+    async def _top_used_bank_entities(self, bank_id: str, *, limit: int = 88) -> list[BankEntitySnapshot]:
+        cap = max(1, int(limit))
+        try:
+            items = await self._list_bank_memories(bank_id, limit=max(120, cap * 3), offset=0)
+        except Exception as exc:
+            logger.warning("peer entities list failed bank=%s: %s", bank_id, exc)
+            return []
+
+        scored: list[tuple[float, BankEntitySnapshot]] = []
+        for idx, item in enumerate(items):
+            entity_id = _pick(item, "id") or _pick(item, "memory_id") or _pick(item, "document_id") or f"mem-{idx}"
+            kind = _pick(item, "type") or _pick(item, "kind") or "memory"
+            text = _pick(item, "content") or _pick(item, "text") or _pick(item, "summary")
+            if not text:
+                continue
+            usage = _usage_score(item, rank_index=idx)
+            scored.append((usage, BankEntitySnapshot(entity_id=entity_id, kind=kind, text=_squash_whitespace(text), usage_score=usage)))
+
+        scored.sort(key=lambda pair: (-pair[0], pair[1].entity_id))
+        return [row for _, row in scored[:cap]]
+
+    async def _list_mental_models(self, bank_id: str) -> list[Any]:
+        client = _base_client(self.embedded)
+        low = getattr(client, "_mental_models_api", None)
+        if low is not None and hasattr(low, "list_mental_models"):
+            timeout = getattr(client, "_timeout", None)
+            out = await low.list_mental_models(bank_id, _request_timeout=timeout)
+            return list(getattr(out, "items", []) or [])
+        # Fallback for clients without low-level async API.
+        listed = await asyncio.to_thread(self.embedded.mental_models.list, bank_id)
+        return list(getattr(listed, "items", []) or [])
+
+    async def _get_mental_model(self, bank_id: str, model_id: str) -> Any:
+        client = _base_client(self.embedded)
+        low = getattr(client, "_mental_models_api", None)
+        if low is not None and hasattr(low, "get_mental_model"):
+            timeout = getattr(client, "_timeout", None)
+            return await low.get_mental_model(bank_id, model_id, _request_timeout=timeout)
+        return await asyncio.to_thread(self.embedded.mental_models.get, bank_id, model_id)
+
+    async def _list_bank_memories(self, bank_id: str, *, limit: int, offset: int) -> list[Any]:
+        client = _base_client(self.embedded)
+        low = getattr(client, "_memory_api", None)
+        if low is not None and hasattr(low, "list_memories"):
+            timeout = getattr(client, "_timeout", None)
+            out = await low.list_memories(
+                bank_id,
+                limit=int(limit),
+                offset=int(offset),
+                _request_timeout=timeout,
+            )
+            return list(getattr(out, "items", []) or [])
+        listed = await asyncio.to_thread(
+            self.embedded.memories.list,
+            bank_id,
+            None,
+            None,
+            int(limit),
+            int(offset),
+        )
+        return list(getattr(listed, "items", []) or [])
+
     async def cortex_recall(
         self,
         query: str,
@@ -56,14 +227,37 @@ class PeerMemoryBridge:
         await self.ensure_bank(bank_id)
         mk: MemoryKind = kind  # type: ignore[assignment]
         try:
-            return await self.recall.recall(
+            out = await self.recall.recall(
                 query,
                 kinds=[mk],
                 bank=bank_id,
                 top_k=self.recall_top_k,
             )
+            await self._append_raw_memory_event(
+                bank_id=bank_id,
+                event="recall",
+                payload={
+                    "query": query,
+                    "kind": kind,
+                    "results": [
+                        {
+                            "kind": r.kind,
+                            "text": r.text,
+                            "score": r.score,
+                            "source": r.source,
+                        }
+                        for r in out
+                    ],
+                },
+            )
+            return out
         except Exception as exc:
             logger.warning("peer recall failed bank=%s: %s", bank_id, exc)
+            await self._append_raw_memory_event(
+                bank_id=bank_id,
+                event="recall_error",
+                payload={"query": query, "kind": kind, "error": f"{type(exc).__name__}: {exc}"},
+            )
             return []
 
     async def retain_turn(
@@ -87,11 +281,89 @@ class PeerMemoryBridge:
         )
         try:
             await self.hippocampus.encode(st, kind="episodic", bank=bank_id)
+            await self._append_raw_memory_event(
+                bank_id=bank_id,
+                event="retain",
+                payload={
+                    "channel": stimulus.channel,
+                    "sender": stimulus.sender,
+                    "user": user,
+                    "assistant": assistant,
+                    "raw_chunk": text,
+                },
+            )
         except Exception as exc:
             logger.warning("peer retain failed bank=%s: %s", bank_id, exc)
+            await self._append_raw_memory_event(
+                bank_id=bank_id,
+                event="retain_error",
+                payload={
+                    "channel": stimulus.channel,
+                    "sender": stimulus.sender,
+                    "error": f"{type(exc).__name__}: {exc}",
+                    "raw_chunk": text,
+                },
+            )
+
+    async def aclose(self) -> None:
+        """Best-effort async close for underlying client resources."""
+
+        target = self.embedded
+        close_async = getattr(target, "aclose", None)
+        if callable(close_async):
+            try:
+                await close_async()
+                return
+            except Exception:
+                pass
+        close_sync = getattr(target, "close", None)
+        if callable(close_sync):
+            try:
+                close_sync()
+            except Exception:
+                pass
+
+    async def startup_healthcheck(self, *, probe_bank_id: str) -> tuple[bool, str]:
+        """Run a lightweight read/write probe for peer-memory backend."""
+
+        try:
+            await self.ensure_bank(probe_bank_id)
+            _ = await self.cortex_recall("healthcheck", "episodic", probe_bank_id)
+            await self.embedded.aretain(
+                bank_id=probe_bank_id,
+                content="cortex peer-memory startup probe",
+                tags=["cortex:healthcheck", "cortex:peer-memory"],
+            )
+            return True, f"peer-memory backend ok (bank={probe_bank_id})"
+        except Exception as exc:
+            return False, f"peer-memory backend unhealthy ({type(exc).__name__}: {exc})"
+
+    async def _append_raw_memory_event(self, *, bank_id: str, event: str, payload: dict[str, Any]) -> None:
+        if self.whatsapp_memory_raw_dir is None:
+            return
+        record = {
+            "at": datetime.now(UTC).isoformat(),
+            "event": event,
+            "bank_id": bank_id,
+            "payload": payload,
+        }
+        path = self.whatsapp_memory_raw_dir / f"{_safe_bank_filename(bank_id)}.jsonl"
+
+        def _write() -> None:
+            self.whatsapp_memory_raw_dir.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(record, ensure_ascii=True) + "\n")
+
+        await asyncio.to_thread(_write)
 
 
-def build_peer_memory_bridge(config: Any, *, cortex_profile: str) -> PeerMemoryBridge | None:
+def build_peer_memory_bridge(
+    config: Any,
+    *,
+    cortex_profile: str,
+    whatsapp_mental_models_dir: Path | None = None,
+    whatsapp_memory_raw_dir: Path | None = None,
+) -> PeerMemoryBridge | None:
     """Construct a bridge when ``memory.peer_banks_enabled`` is true.
 
     Returns ``None`` if the optional ``atulya`` package cannot be imported
@@ -101,16 +373,24 @@ def build_peer_memory_bridge(config: Any, *, cortex_profile: str) -> PeerMemoryB
     if not getattr(config.memory, "peer_banks_enabled", False):
         return None
     try:
-        from atulya import AtulyaEmbedded
+        from atulya import AtulyaClient, AtulyaEmbedded
     except ImportError:
         logger.warning("peer banks: atulya package not importable; skipping")
         return None
 
-    ep = (getattr(config.memory, "embed_profile", "") or "").strip()
-    embed_profile = ep or cortex_profile
+    backend = (getattr(config.memory, "peer_banks_backend", "embedded") or "embedded").strip().lower()
     bank_fallback = getattr(config.memory, "bank_id", "atulya-cortex")
     try:
-        emb = AtulyaEmbedded(profile=embed_profile)
+        if backend == "api":
+            api_key_env = (getattr(config.memory, "api_key_env", "") or "").strip()
+            api_key = os.environ.get(api_key_env, "") if api_key_env else ""
+            emb = AtulyaClient(base_url=config.memory.api_url, api_key=api_key or None)
+            logger.info("peer banks: using api backend at %s", config.memory.api_url)
+        else:
+            ep = (getattr(config.memory, "embed_profile", "") or "").strip()
+            embed_profile = ep or cortex_profile
+            emb = AtulyaEmbedded(profile=embed_profile)
+            logger.info("peer banks: using embedded backend profile=%s", embed_profile)
         hip = Hippocampus(emb, default_bank=bank_fallback)
         rec = Recall(emb, default_bank=bank_fallback)
         return PeerMemoryBridge(
@@ -118,6 +398,8 @@ def build_peer_memory_bridge(config: Any, *, cortex_profile: str) -> PeerMemoryB
             hippocampus=hip,
             recall=rec,
             recall_top_k=int(config.memory.recall_top_k),
+            whatsapp_mental_models_dir=whatsapp_mental_models_dir,
+            whatsapp_memory_raw_dir=whatsapp_memory_raw_dir,
         )
     except Exception as exc:
         logger.warning("peer banks: could not start embedded client: %s", exc)
@@ -125,3 +407,53 @@ def build_peer_memory_bridge(config: Any, *, cortex_profile: str) -> PeerMemoryB
 
 
 __all__ = ["PeerMemoryBridge", "build_peer_memory_bridge"]
+
+
+def _pick(obj: Any, key: str) -> str:
+    if isinstance(obj, dict):
+        value = obj.get(key, "")
+    else:
+        value = getattr(obj, key, "")
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _squash_whitespace(text: str) -> str:
+    return " ".join(text.split())
+
+
+def _usage_score(item: Any, *, rank_index: int) -> float:
+    keys = (
+        "usage_count",
+        "uses",
+        "access_count",
+        "hit_count",
+        "times_used",
+        "importance",
+        "score",
+    )
+    for key in keys:
+        raw = _pick(item, key)
+        if not raw:
+            continue
+        try:
+            return float(raw)
+        except Exception:
+            continue
+    # Fallback: preserve upstream ordering from API if no explicit usage field.
+    return max(0.0, 1_000_000.0 - float(rank_index))
+
+
+def _base_client(embedded: Any) -> Any:
+    # AtulyaEmbedded exposes `.client`; plain Atulya/AtulyaClient is itself the base client.
+    if hasattr(embedded, "client"):
+        try:
+            return embedded.client
+        except Exception:
+            return embedded
+    return embedded
+
+
+def _safe_bank_filename(bank_id: str) -> str:
+    return "".join(ch if ch.isalnum() or ch in ("-", "_", ".") else "_" for ch in bank_id)[:160] or "bank"

--- a/atulya-cortex/cortex/peer_mental_model_store.py
+++ b/atulya-cortex/cortex/peer_mental_model_store.py
@@ -1,0 +1,198 @@
+"""peer_mental_model_store.py — file-backed mirror of peer mental models.
+
+For remote channels (especially WhatsApp), operators often want an on-disk
+artifact alongside DB state. This module writes one JSON file per peer under:
+
+    ~/.atulya/cortex/whatsapp/mental-models/<phone-or-peer>.json
+
+The file stores current mental models plus a local delta log.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class MentalModelSnapshot:
+    model_id: str
+    name: str
+    content: str
+
+    @property
+    def content_hash(self) -> str:
+        return hashlib.sha256(self.content.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class BankEntitySnapshot:
+    entity_id: str
+    kind: str
+    text: str
+    usage_score: float = 0.0
+
+
+def sync_peer_mental_model_file(
+    *,
+    directory: Path,
+    peer_key: str,
+    bank_id: str,
+    models: list[MentalModelSnapshot],
+    entities: list[BankEntitySnapshot] | None = None,
+    max_delta_entries: int = 500,
+) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{_peer_file_stem(peer_key)}.json"
+    old = _read_json(path)
+    old_models = _index_models(old.get("mental_models", []))
+
+    current = {m.model_id: m for m in models}
+    delta = list(old.get("delta", [])) if isinstance(old.get("delta", []), list) else []
+    now = _iso_now()
+
+    for model_id, model in current.items():
+        prev = old_models.get(model_id)
+        if prev is None:
+            delta.append(
+                {
+                    "at": now,
+                    "change": "created",
+                    "mental_model_id": model_id,
+                    "name": model.name,
+                    "new_hash": model.content_hash,
+                }
+            )
+            continue
+        if prev.get("content_hash") != model.content_hash:
+            delta.append(
+                {
+                    "at": now,
+                    "change": "updated",
+                    "mental_model_id": model_id,
+                    "name": model.name,
+                    "old_hash": prev.get("content_hash", ""),
+                    "new_hash": model.content_hash,
+                }
+            )
+
+    for model_id, prev in old_models.items():
+        if model_id not in current:
+            delta.append(
+                {
+                    "at": now,
+                    "change": "deleted",
+                    "mental_model_id": model_id,
+                    "name": prev.get("name", ""),
+                    "old_hash": prev.get("content_hash", ""),
+                }
+            )
+
+    entities = list(entities or [])
+    entities_hash = _entities_hash(entities)
+    old_entities_hash = str(old.get("top_entities_hash", "")).strip()
+    if entities_hash != old_entities_hash:
+        delta.append(
+            {
+                "at": now,
+                "change": "entities_updated",
+                "entities_count": len(entities),
+                "old_hash": old_entities_hash,
+                "new_hash": entities_hash,
+            }
+        )
+
+    if max_delta_entries > 0 and len(delta) > max_delta_entries:
+        delta = delta[-max_delta_entries:]
+
+    payload = {
+        "schema_version": 1,
+        "peer_key": peer_key,
+        "phone_number": _extract_phone_digits(peer_key),
+        "bank_id": bank_id,
+        "synced_at": now,
+        "mental_models": [
+            {
+                "mental_model_id": m.model_id,
+                "name": m.name,
+                "content": m.content,
+                "content_hash": m.content_hash,
+            }
+            for m in models
+        ],
+        "top_entities": [
+            {
+                "entity_id": e.entity_id,
+                "kind": e.kind,
+                "text": e.text,
+                "usage_score": round(float(e.usage_score), 6),
+            }
+            for e in entities
+        ],
+        "top_entities_hash": entities_hash,
+        "delta": delta,
+    }
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+    return path
+
+
+def _peer_file_stem(peer_key: str) -> str:
+    phone = _extract_phone_digits(peer_key)
+    if phone:
+        return phone
+    stem = re.sub(r"[^a-zA-Z0-9._-]+", "_", peer_key).strip("_")
+    return stem[:80] or "unknown-peer"
+
+
+def _extract_phone_digits(peer_key: str) -> str:
+    head = (peer_key or "").split("@", 1)[0]
+    digits = "".join(ch for ch in head if ch.isdigit())
+    return digits[:24]
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        return raw if isinstance(raw, dict) else {}
+    except Exception:
+        return {}
+
+
+def _index_models(items: list[Any]) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        model_id = str(item.get("mental_model_id", "")).strip()
+        if not model_id:
+            continue
+        out[model_id] = item
+    return out
+
+
+def _iso_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _entities_hash(entities: list[BankEntitySnapshot]) -> str:
+    raw = [
+        {
+            "entity_id": e.entity_id,
+            "kind": e.kind,
+            "text": e.text,
+            "usage_score": round(float(e.usage_score), 6),
+        }
+        for e in entities
+    ]
+    return hashlib.sha256(json.dumps(raw, ensure_ascii=True, sort_keys=True).encode("utf-8")).hexdigest()
+
+
+__all__ = ["BankEntitySnapshot", "MentalModelSnapshot", "sync_peer_mental_model_file"]
+

--- a/atulya-cortex/cortex/plasticity_prompt_memory.py
+++ b/atulya-cortex/cortex/plasticity_prompt_memory.py
@@ -1,0 +1,379 @@
+"""plasticity_prompt_memory.py — adaptive prompt guidance + genome distillation."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_DIRECTIVE_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"\b(concise|short|brief)\b", re.IGNORECASE), "Keep replies concise."),
+    (re.compile(r"\b(no emoji|without emoji|stop emoji)\b", re.IGNORECASE), "Avoid emojis unless asked."),
+    (re.compile(r"\b(casual|human|natural)\b", re.IGNORECASE), "Use natural human conversational tone."),
+    (re.compile(r"\b(step by step|steps)\b", re.IGNORECASE), "Prefer step-by-step structure when useful."),
+    (re.compile(r"\b(execute|run command|run this)\b", re.IGNORECASE), "If execution is restricted, clearly say limits and next action."),
+)
+logger = logging.getLogger(__name__)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass(frozen=True)
+class PlasticityPromptSettings:
+    enabled: bool = False
+    per_user_enabled: bool = True
+    system_enabled: bool = True
+    max_directives: int = 6
+    time_context_enabled: bool = True
+    distill_enabled: bool = True
+    distill_min_updates: int = 5
+    distill_cooldown_s: float = 300.0
+    distill_max_versions: int = 16
+
+
+class PlasticityPromptMemory:
+    def __init__(self, path: Path, settings: PlasticityPromptSettings) -> None:
+        self._path = path
+        self._settings = settings
+
+    def record_turn(self, *, peer_key: str | None, user_text: str, assistant_text: str) -> None:
+        if not self._settings.enabled:
+            return
+        directives = self._extract_directives(user_text or "")
+        if not directives:
+            return
+        data = self._load()
+        if self._settings.system_enabled:
+            bucket = data.setdefault("system", [])
+            for d in directives:
+                self._upsert(bucket, d)
+            data["system_pending_updates"] = int(data.get("system_pending_updates", 0)) + len(directives)
+        if self._settings.per_user_enabled and peer_key:
+            peers = data.setdefault("peers", {})
+            bucket = peers.setdefault(peer_key, [])
+            for d in directives:
+                self._upsert(bucket, d)
+            pending = data.setdefault("peer_pending_updates", {})
+            pending[peer_key] = int(pending.get(peer_key, 0)) + len(directives)
+        self._save(data)
+
+    def prompt_block(self, *, peer_key: str | None) -> str:
+        if not self._settings.enabled:
+            return ""
+        data = self._load()
+        lines: list[str] = []
+        if self._settings.system_enabled:
+            top = self._top_directives(data.get("system", []), self._settings.max_directives)
+            if top:
+                lines.append("Adaptive system guidance:")
+                lines.extend(f"- {item['directive']}" for item in top)
+            system_genome = str(data.get("system_genome", "")).strip()
+            if system_genome:
+                lines.append("System prompt genome:")
+                lines.append(system_genome)
+        if self._settings.per_user_enabled and peer_key:
+            peers = data.get("peers", {})
+            top_peer = self._top_directives(peers.get(peer_key, []), self._settings.max_directives)
+            if top_peer:
+                lines.append("Adaptive peer guidance:")
+                lines.extend(f"- {item['directive']}" for item in top_peer)
+            peer_genome = str(data.get("peer_genomes", {}).get(peer_key, "")).strip()
+            if peer_genome:
+                lines.append("Peer prompt genome:")
+                lines.append(peer_genome)
+        return "\n".join(lines).strip()
+
+    @property
+    def time_context_enabled(self) -> bool:
+        return bool(self._settings.time_context_enabled)
+
+    @property
+    def distill_enabled(self) -> bool:
+        return bool(self._settings.enabled and self._settings.distill_enabled)
+
+    async def distill_if_due(
+        self,
+        *,
+        language: Any | None,
+        provider: str | None,
+        model: str | None,
+        temperature: float,
+        max_tokens: int | None,
+        peer_key: str | None,
+    ) -> None:
+        if not self.distill_enabled or language is None:
+            return
+        data = self._load()
+        now = datetime.now(timezone.utc)
+
+        if self._settings.system_enabled:
+            await self._distill_scope_if_due(
+                data=data,
+                scope="system",
+                directives=self._top_directives(data.get("system", []), self._settings.max_directives),
+                pending_updates=int(data.get("system_pending_updates", 0)),
+                last_key="system_last_distilled_at",
+                versions_key="system_genome_versions",
+                genome_setter=lambda genome: data.__setitem__("system_genome", genome),
+                pending_clearer=lambda: data.__setitem__("system_pending_updates", 0),
+                now=now,
+                language=language,
+                provider=provider,
+                model=model,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+
+        if self._settings.per_user_enabled and peer_key:
+            peers = data.get("peers", {})
+            peer_items = self._top_directives(peers.get(peer_key, []), self._settings.max_directives)
+            pending = data.setdefault("peer_pending_updates", {})
+            pending_count = int(pending.get(peer_key, 0))
+            peer_genomes = data.setdefault("peer_genomes", {})
+            versions_root = data.setdefault("peer_genome_versions", {})
+            await self._distill_scope_if_due(
+                data=data,
+                scope=f"peer:{peer_key}",
+                directives=peer_items,
+                pending_updates=pending_count,
+                last_key=f"peer_last_distilled_at:{peer_key}",
+                versions_key=f"peer_versions:{peer_key}",
+                genome_setter=lambda genome: peer_genomes.__setitem__(peer_key, genome),
+                pending_clearer=lambda: pending.__setitem__(peer_key, 0),
+                now=now,
+                language=language,
+                provider=provider,
+                model=model,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                versions_store=versions_root,
+            )
+        self._save(data)
+
+    def rollback(self, *, peer_key: str | None = None) -> bool:
+        data = self._load()
+        if peer_key:
+            versions_root = data.get("peer_genome_versions", {})
+            versions = versions_root.get(peer_key, [])
+            if len(versions) < 2:
+                return False
+            versions.pop()
+            prior = versions[-1]
+            data.setdefault("peer_genomes", {})[peer_key] = prior.get("genome", "")
+            self._save(data)
+            return True
+        versions = data.get("system_genome_versions", [])
+        if len(versions) < 2:
+            return False
+        versions.pop()
+        prior = versions[-1]
+        data["system_genome"] = prior.get("genome", "")
+        self._save(data)
+        return True
+
+    @staticmethod
+    def _extract_directives(text: str) -> list[str]:
+        out: list[str] = []
+        for pattern, directive in _DIRECTIVE_RULES:
+            if pattern.search(text) and directive not in out:
+                out.append(directive)
+        return out
+
+    @staticmethod
+    def _upsert(bucket: list[dict[str, Any]], directive: str) -> None:
+        now = _now_iso()
+        for item in bucket:
+            if item.get("directive") == directive:
+                item["count"] = int(item.get("count", 0)) + 1
+                item["updated_at"] = now
+                return
+        bucket.append({"directive": directive, "count": 1, "updated_at": now})
+
+    @staticmethod
+    def _top_directives(bucket: list[dict[str, Any]], max_items: int) -> list[dict[str, Any]]:
+        items = list(bucket or [])
+        items.sort(
+            key=lambda x: (
+                -int(x.get("count", 0)),
+                str(x.get("updated_at", "")),
+                str(x.get("directive", "")),
+            )
+        )
+        return items[: max(1, int(max_items))]
+
+    def _load(self) -> dict[str, Any]:
+        if not self._path.exists():
+            return {
+                "schema_version": 2,
+                "system": [],
+                "peers": {},
+                "system_pending_updates": 0,
+                "peer_pending_updates": {},
+                "system_genome": "",
+                "peer_genomes": {},
+                "system_genome_versions": [],
+                "peer_genome_versions": {},
+            }
+        try:
+            payload = json.loads(self._path.read_text(encoding="utf-8"))
+            payload.setdefault("schema_version", 2)
+            payload.setdefault("system", [])
+            payload.setdefault("peers", {})
+            payload.setdefault("system_pending_updates", 0)
+            payload.setdefault("peer_pending_updates", {})
+            payload.setdefault("system_genome", "")
+            payload.setdefault("peer_genomes", {})
+            payload.setdefault("system_genome_versions", [])
+            payload.setdefault("peer_genome_versions", {})
+            return payload
+        except Exception:
+            return {
+                "schema_version": 2,
+                "system": [],
+                "peers": {},
+                "system_pending_updates": 0,
+                "peer_pending_updates": {},
+                "system_genome": "",
+                "peer_genomes": {},
+                "system_genome_versions": [],
+                "peer_genome_versions": {},
+            }
+
+    def _save(self, payload: dict[str, Any]) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._path.write_text(json.dumps(payload, ensure_ascii=True, indent=2), encoding="utf-8")
+
+    async def _distill_scope_if_due(
+        self,
+        *,
+        data: dict[str, Any],
+        scope: str,
+        directives: list[dict[str, Any]],
+        pending_updates: int,
+        last_key: str,
+        versions_key: str,
+        genome_setter,
+        pending_clearer,
+        now: datetime,
+        language: Any,
+        provider: str | None,
+        model: str | None,
+        temperature: float,
+        max_tokens: int | None,
+        versions_store: dict[str, Any] | None = None,
+    ) -> None:
+        if pending_updates < int(self._settings.distill_min_updates):
+            return
+        last_iso = str(data.get(last_key, "")).strip()
+        if last_iso:
+            try:
+                last_dt = datetime.fromisoformat(last_iso)
+                elapsed = max(0.0, (now - last_dt).total_seconds())
+                if elapsed < float(self._settings.distill_cooldown_s):
+                    return
+            except ValueError:
+                pass
+        if not directives:
+            return
+        genome = await self._distill_with_llm(
+            language=language,
+            scope=scope,
+            directives=directives,
+            provider=provider,
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+        if not genome:
+            return
+        genome_setter(genome)
+        data[last_key] = _now_iso()
+        pending_clearer()
+        entry = {"at": _now_iso(), "genome": genome}
+        if versions_store is None:
+            versions = data.setdefault(versions_key, [])
+        else:
+            versions = versions_store.setdefault(scope.split("peer:", 1)[-1], [])
+        versions.append(entry)
+        keep = max(1, int(self._settings.distill_max_versions))
+        if len(versions) > keep:
+            del versions[:-keep]
+
+    async def _distill_with_llm(
+        self,
+        *,
+        language: Any,
+        scope: str,
+        directives: list[dict[str, Any]],
+        provider: str | None,
+        model: str | None,
+        temperature: float,
+        max_tokens: int | None,
+    ) -> str:
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "Compress prompt directives into a compact prompt genome.\n"
+                    "Return strict JSON: {\"genome\":\"...\"}.\n"
+                    "Genome must be 3-6 short bullets, each imperative and non-redundant."
+                ),
+            },
+            {
+                "role": "user",
+                "content": json.dumps(
+                    {
+                        "scope": scope,
+                        "directives": [
+                            {"directive": d.get("directive", ""), "count": int(d.get("count", 0))}
+                            for d in directives
+                        ],
+                    },
+                    ensure_ascii=True,
+                ),
+            },
+        ]
+        try:
+            utt = await language.think(
+                messages,
+                provider=provider,
+                model=model,
+                temperature=min(float(temperature), 0.2),
+                max_tokens=min(int(max_tokens or 256), 256),
+            )
+        except Exception as exc:  # pragma: no cover
+            logger.warning("plasticity distill failed scope=%s: %s", scope, exc)
+            return ""
+        payload = self._parse_json_dict(str(getattr(utt, "text", "") or "").strip())
+        genome = str(payload.get("genome", "")).strip()
+        return genome
+
+    @staticmethod
+    def _parse_json_dict(text: str) -> dict[str, Any]:
+        if not text:
+            return {}
+        try:
+            out = json.loads(text)
+            if isinstance(out, dict):
+                return out
+        except json.JSONDecodeError:
+            pass
+        start = text.find("{")
+        end = text.rfind("}")
+        if 0 <= start < end:
+            try:
+                out = json.loads(text[start : end + 1])
+                if isinstance(out, dict):
+                    return out
+            except json.JSONDecodeError:
+                pass
+        return {}
+
+
+__all__ = ["PlasticityPromptMemory", "PlasticityPromptSettings"]

--- a/atulya-cortex/cortex/self_healing.py
+++ b/atulya-cortex/cortex/self_healing.py
@@ -1,0 +1,343 @@
+"""self_healing.py — global reply quality guard + efficient auto-repair.
+
+The self-healing layer is intentionally two-stage:
+
+1) Cheap deterministic checks (empty / orphan tool tags / too short).
+2) Optional LLM judge+repair pass only when stage (1) flags a risk.
+
+This keeps hot-path latency low while still recovering from model slips.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_ORPHAN_TAG_RE = re.compile(r"<(/?tool(?:_result)?[^>]*)>", flags=re.IGNORECASE)
+_EXEC_INTENT_RE = re.compile(
+    r"\b(run|execute|check|inspect|show|measure|test|use)\b",
+    flags=re.IGNORECASE,
+)
+
+try:
+    from plasticity.attention_network import AttentionEntity, route_entities
+except Exception:  # pragma: no cover - optional dependency safety
+    AttentionEntity = None  # type: ignore[assignment]
+    route_entities = None  # type: ignore[assignment]
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass(frozen=True)
+class SelfHealingSettings:
+    enabled: bool = False
+    max_retries: int = 1
+    min_reply_chars: int = 8
+    judge_enabled: bool = True
+    judge_provider: str = ""
+    judge_model: str = ""
+    fallback_text: str = "I hit a response glitch. Please retry that once."
+    telemetry_enabled: bool = True
+
+
+@dataclass(frozen=True)
+class HealingResult:
+    text: str
+    healed: bool
+    reason: str = ""
+    attempts: int = 0
+
+
+class SelfHealingEngine:
+    """Guards reply quality and optionally self-repairs via LLM judge."""
+
+    def __init__(self, settings: SelfHealingSettings, *, telemetry_file: Path | None = None) -> None:
+        self._settings = settings
+        self._telemetry_file = telemetry_file
+
+    async def heal_reply(
+        self,
+        *,
+        language: Any | None,
+        stimulus_text: str,
+        draft_reply: str,
+        provider: str | None,
+        model: str | None,
+        temperature: float,
+        max_tokens: int | None,
+        channel: str,
+        peer_key: str | None,
+    ) -> HealingResult:
+        if not self._settings.enabled:
+            return HealingResult(text=draft_reply, healed=False)
+
+        reasons = self._detect_issues(stimulus_text, draft_reply)
+        if "tool_payload_leak" in reasons:
+            repaired = self._intent_repair_for_tool_payload(
+                stimulus_text=stimulus_text,
+                draft_reply=draft_reply,
+                channel=channel,
+            )
+            if repaired:
+                self._record_event(
+                    channel=channel,
+                    peer_key=peer_key,
+                    status="healed_intent_tool_payload",
+                    reasons=self._rank_reasons(reasons),
+                    attempts=0,
+                    old_reply=draft_reply,
+                    new_reply=repaired,
+                )
+                return HealingResult(text=repaired, healed=True, reason="intent_tool_payload", attempts=0)
+        if not reasons:
+            return HealingResult(text=draft_reply, healed=False)
+        ranked_reasons = self._rank_reasons(reasons)
+
+        if not self._settings.judge_enabled or language is None or self._settings.max_retries <= 0:
+            fallback = self._settings.fallback_text
+            self._record_event(
+                channel=channel,
+                peer_key=peer_key,
+                status="fallback_no_judge",
+                reasons=ranked_reasons,
+                attempts=0,
+                old_reply=draft_reply,
+                new_reply=fallback,
+            )
+            return HealingResult(text=fallback, healed=True, reason="fallback_no_judge", attempts=0)
+
+        current = draft_reply
+        for attempt in range(1, self._settings.max_retries + 1):
+            repaired = await self._judge_and_repair(
+                language=language,
+                stimulus_text=stimulus_text,
+                draft_reply=current,
+                reasons=ranked_reasons,
+                provider=provider,
+                model=model,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+            if not repaired:
+                continue
+            if not self._detect_issues(stimulus_text, repaired):
+                self._record_event(
+                    channel=channel,
+                    peer_key=peer_key,
+                    status="healed",
+                    reasons=ranked_reasons,
+                    attempts=attempt,
+                    old_reply=draft_reply,
+                    new_reply=repaired,
+                )
+                return HealingResult(text=repaired, healed=True, reason="judge_repair", attempts=attempt)
+            current = repaired
+
+        fallback = self._settings.fallback_text
+        self._record_event(
+            channel=channel,
+            peer_key=peer_key,
+            status="fallback_after_retries",
+            reasons=ranked_reasons,
+            attempts=self._settings.max_retries,
+            old_reply=draft_reply,
+            new_reply=fallback,
+        )
+        return HealingResult(
+            text=fallback,
+            healed=True,
+            reason="fallback_after_retries",
+            attempts=self._settings.max_retries,
+        )
+
+    def _detect_issues(self, stimulus_text: str, reply: str) -> list[str]:
+        out: list[str] = []
+        clean = (reply or "").strip()
+        if not clean:
+            out.append("empty_reply")
+        if _ORPHAN_TAG_RE.search(clean):
+            out.append("orphan_tool_tag")
+        if clean and len(clean) < self._settings.min_reply_chars and len((stimulus_text or "").strip()) >= 6:
+            out.append("too_short")
+        if self._is_tool_payload_leak(stimulus_text, clean):
+            out.append("tool_payload_leak")
+        return out
+
+    def _is_tool_payload_leak(self, stimulus_text: str, reply: str) -> bool:
+        if not reply:
+            return False
+        payload = self._parse_json_dict(reply)
+        if not payload:
+            return False
+        keys = {str(k).strip().lower() for k in payload.keys()}
+        toolish = bool({"command", "name", "arguments"} & keys)
+        if not toolish:
+            return False
+        # Trigger only when the user likely asked for an action, to avoid
+        # false positives for genuine JSON discussions.
+        return bool(_EXEC_INTENT_RE.search(stimulus_text or ""))
+
+    def _intent_repair_for_tool_payload(self, *, stimulus_text: str, draft_reply: str, channel: str) -> str:
+        payload = self._parse_json_dict(draft_reply)
+        command = str(payload.get("command", "")).strip()
+        tool_name = str(payload.get("name", "")).strip()
+        requested = command or tool_name or "that action"
+        channel_root = channel.split(":", 1)[0] if channel else "this"
+        return (
+            f"I understood you want me to execute `{requested}`. "
+            f"I cannot run tools directly on {channel_root} right now, so I gave you the command form earlier. "
+            "If you want execution, run it in trusted TUI/tool-enabled mode; otherwise I can explain the output and next steps."
+        )
+
+    async def _judge_and_repair(
+        self,
+        *,
+        language: Any,
+        stimulus_text: str,
+        draft_reply: str,
+        reasons: list[str],
+        provider: str | None,
+        model: str | None,
+        temperature: float,
+        max_tokens: int | None,
+    ) -> str:
+        judge_messages = [
+            {
+                "role": "system",
+                "content": (
+                    "You are a response quality gate. Fix the assistant draft if needed.\n"
+                    "Return strict JSON with keys: verdict, repaired_reply, confidence, notes.\n"
+                    "verdict must be one of: keep, repair.\n"
+                    "Keep repaired_reply concise and directly useful for the user."
+                ),
+            },
+            {
+                "role": "user",
+                "content": json.dumps(
+                    {
+                        "user_message": stimulus_text,
+                        "assistant_draft": draft_reply,
+                        "detected_issues": reasons,
+                    },
+                    ensure_ascii=True,
+                ),
+            },
+        ]
+        try:
+            utt = await language.think(
+                judge_messages,
+                provider=self._settings.judge_provider or provider,
+                model=self._settings.judge_model or model,
+                temperature=min(0.2, float(temperature)),
+                max_tokens=min(int(max_tokens or 256), 256),
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("self-heal judge failed: %s", exc)
+            return ""
+        payload = self._parse_json_dict((getattr(utt, "text", "") or "").strip())
+        repaired = str(payload.get("repaired_reply", "")).strip()
+        verdict = str(payload.get("verdict", "")).strip().lower()
+        if verdict == "keep" and not repaired:
+            repaired = draft_reply
+        return repaired
+
+    def _rank_reasons(self, reasons: list[str]) -> list[str]:
+        if not reasons or AttentionEntity is None or route_entities is None:
+            return reasons
+        entities: list[Any] = []
+        score_map = {
+            "empty_reply": 1.0,
+            "orphan_tool_tag": 0.85,
+            "tool_payload_leak": 0.8,
+            "too_short": 0.55,
+        }
+        for idx, reason in enumerate(reasons):
+            entities.append(
+                AttentionEntity(
+                    entity_id=f"heal-{reason}-{idx}",
+                    category="system_state",
+                    payload={"reason": reason},
+                    semantic_relevance=score_map.get(reason, 0.4),
+                    recency=1.0,
+                    task_alignment=0.9,
+                    user_intent=0.7,
+                    system_state=1.0,
+                )
+            )
+        decision = route_entities(entities, per_category_limit=8, total_limit=8)
+        ranked: list[str] = []
+        for item in decision.selected:
+            reason = str(item.entity.payload.get("reason", "")).strip()
+            if reason and reason not in ranked:
+                ranked.append(reason)
+        return ranked or reasons
+
+    def _record_event(
+        self,
+        *,
+        channel: str,
+        peer_key: str | None,
+        status: str,
+        reasons: list[str],
+        attempts: int,
+        old_reply: str,
+        new_reply: str,
+    ) -> None:
+        if not self._settings.telemetry_enabled:
+            return
+        event = {
+            "at": _now_iso(),
+            "channel": channel,
+            "peer_key": peer_key or "",
+            "status": status,
+            "reasons": reasons,
+            "attempts": attempts,
+            "old_reply_chars": len((old_reply or "").strip()),
+            "new_reply_chars": len((new_reply or "").strip()),
+        }
+        logger.info("self-heal: %s", event)
+        if self._telemetry_file is None:
+            return
+        try:
+            self._telemetry_file.parent.mkdir(parents=True, exist_ok=True)
+            with self._telemetry_file.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(event, ensure_ascii=True) + "\n")
+        except Exception:  # pragma: no cover - file telemetry must never break reply path
+            logger.warning("self-heal telemetry write failed", exc_info=True)
+
+    @staticmethod
+    def _parse_json_dict(text: str) -> dict[str, Any]:
+        if not text:
+            return {}
+        try:
+            parsed = json.loads(text)
+            if isinstance(parsed, dict):
+                return parsed
+        except json.JSONDecodeError:
+            pass
+        start = text.find("{")
+        end = text.rfind("}")
+        if 0 <= start < end:
+            try:
+                parsed = json.loads(text[start : end + 1])
+                if isinstance(parsed, dict):
+                    return parsed
+            except json.JSONDecodeError:
+                pass
+        return {}
+
+
+__all__ = [
+    "HealingResult",
+    "SelfHealingEngine",
+    "SelfHealingSettings",
+]

--- a/atulya-cortex/cortex/setup_wizard.py
+++ b/atulya-cortex/cortex/setup_wizard.py
@@ -455,7 +455,12 @@ class SetupWizard:
         )
         cfg.memory.api_url = self.prompter.ask(
             "atulya-api endpoint",
-            default=cfg.memory.api_url or "http://localhost:8000",
+            default=cfg.memory.api_url or "http://localhost:8888",
+        )
+        cfg.memory.peer_banks_backend = self.prompter.ask_choice(
+            "Peer-bank backend",
+            ["embedded", "api"],
+            default_index=0 if (cfg.memory.peer_banks_backend or "embedded") == "embedded" else 1,
         )
         if self.prompter.ask_yes_no("Does your atulya-api require an auth token?", default=False):
             key_env = self.prompter.ask(

--- a/atulya-cortex/cortex/templates/config.toml
+++ b/atulya-cortex/cortex/templates/config.toml
@@ -47,6 +47,10 @@ peer_banks_enabled = true
 peer_banks_channels = ["whatsapp", "telegram"]
 # Optional: atulya-embed daemon profile name. Empty = same as cortex profile.
 embed_profile = ""
+# Peer-bank backend:
+# - "embedded": use AtulyaEmbedded daemon/profile (often :8984)
+# - "api": use memory.api_url directly (often :8888; visible in default UI)
+peer_banks_backend = "embedded"
 # atulya-api endpoint (atulya-embed daemon). Leave default for the local stack.
 api_url = "http://localhost:8888"
 # Env var that holds the atulya-api auth token, if your deployment requires one.
@@ -152,3 +156,42 @@ web_fetch_enabled = true
 web_fetch_timeout_s = 30.0
 web_fetch_max_bytes = 2000000
 fs_write_enabled = true
+
+[self_healing]
+# Global reply self-healing for all channels (TUI, WhatsApp, Telegram).
+# Fast path is deterministic checks; optional LLM judge runs only on faults.
+enabled = true
+# Number of repair attempts after a bad draft is detected.
+max_retries = 1
+# Replies below this length (for non-trivial user messages) are flagged.
+min_reply_chars = 8
+# Use LLM judge+repair on faults; if false, fallback_text is sent directly.
+judge_enabled = true
+# Optional override for judge provider/model. Empty = use primary model config.
+judge_provider = ""
+judge_model = ""
+# Last-resort message when repair fails or judge is disabled.
+fallback_text = "I hit a response glitch. Please retry that once."
+# Write JSONL telemetry in logs/self-healing.jsonl + structured logger events.
+telemetry_enabled = true
+
+[plasticity]
+# Adaptive prompt memory for brain growth:
+# learns high-signal guidance from turns and re-injects it into prompts.
+enabled = true
+# Learn and inject guidance specific to each peer/channel identity.
+per_user_enabled = true
+# Learn and inject guidance that applies across peers (system-wide).
+system_enabled = true
+# Max learned directives injected per scope.
+max_directives = 6
+# Inject explicit temporal context in prompts on every reflection.
+time_context_enabled = true
+# Distill learned directives into compact "prompt genomes" with LLM judge.
+distill_enabled = true
+# Minimum new directive updates before a distillation run is considered.
+distill_min_updates = 5
+# Minimum seconds between distillation runs for the same scope.
+distill_cooldown_s = 300.0
+# Keep this many genome versions per scope for rollback.
+distill_max_versions = 16

--- a/atulya-cortex/plasticity/__init__.py
+++ b/atulya-cortex/plasticity/__init__.py
@@ -32,6 +32,17 @@ that produces it is a `Compiler` or a `TextGradient`.
 from __future__ import annotations
 
 from plasticity.compiler import BootstrapReport, Compiler
+from plasticity.attention_network import (
+    AttentionDecision,
+    AttentionEntity,
+    AttentionWeights,
+    hash_binary_with_brain_metadata,
+    persist_ip_as_binary,
+    ping_local_model,
+    request_structured_response,
+    route_entities,
+    score_entity,
+)
 from plasticity.engine import (
     LanguageEngine,
     build_dspy_lm,
@@ -54,6 +65,9 @@ from plasticity.store import load_compiled, save_compiled
 __all__ = [
     "BootstrapReport",
     "Compiler",
+    "AttentionDecision",
+    "AttentionEntity",
+    "AttentionWeights",
     "Demo",
     "EvalReport",
     "Example",
@@ -65,11 +79,17 @@ __all__ = [
     "TextGradient",
     "build_dspy_lm",
     "build_textgrad_engine",
+    "hash_binary_with_brain_metadata",
     "contains",
     "evaluate",
     "exact_match",
     "llm_judge",
     "load_compiled",
+    "persist_ip_as_binary",
+    "ping_local_model",
     "regex_match",
+    "request_structured_response",
+    "route_entities",
     "save_compiled",
+    "score_entity",
 ]

--- a/atulya-cortex/plasticity/attention_network.py
+++ b/atulya-cortex/plasticity/attention_network.py
@@ -1,0 +1,340 @@
+"""attention_network.py — deterministic attention routing for cortex/plasticity.
+
+A compact cognitive-router layer that can:
+
+1. Score/rank entities across 8 categories with weighted attention signals.
+2. Build deterministic routing decisions for memory/agents/tools/tasks.
+3. Persist an IP address as packed binary bytes.
+4. Hash the binary payload with `BRAIN.md` metadata for provenance tracking.
+5. Probe local OpenAI-compatible model hosts (LM Studio/Ollama-style) and
+   request structured JSON responses.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import ipaddress
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+import httpx
+
+AttentionCategory = Literal[
+    "memory",
+    "agent",
+    "tool",
+    "task",
+    "user_intent",
+    "system_state",
+    "input_context",
+    "output_context",
+]
+
+
+@dataclass(frozen=True)
+class AttentionWeights:
+    semantic_relevance: float = 0.35
+    recency: float = 0.2
+    task_alignment: float = 0.2
+    user_intent: float = 0.15
+    system_state: float = 0.1
+
+
+@dataclass(frozen=True)
+class AttentionEntity:
+    entity_id: str
+    category: AttentionCategory
+    payload: dict[str, Any] = field(default_factory=dict)
+    semantic_relevance: float = 0.0
+    recency: float = 0.0
+    task_alignment: float = 0.0
+    user_intent: float = 0.0
+    system_state: float = 0.0
+
+
+@dataclass(frozen=True)
+class ScoredEntity:
+    entity: AttentionEntity
+    score: float
+
+
+@dataclass(frozen=True)
+class AttentionDecision:
+    ranked: tuple[ScoredEntity, ...]
+    selected: tuple[ScoredEntity, ...]
+    banks: dict[AttentionCategory, tuple[ScoredEntity, ...]]
+    trajectory: dict[AttentionCategory, float]
+
+
+def _clamp01(value: float) -> float:
+    if value < 0.0:
+        return 0.0
+    if value > 1.0:
+        return 1.0
+    return value
+
+
+def score_entity(entity: AttentionEntity, weights: AttentionWeights | None = None) -> float:
+    w = weights or AttentionWeights()
+    return (
+        w.semantic_relevance * _clamp01(entity.semantic_relevance)
+        + w.recency * _clamp01(entity.recency)
+        + w.task_alignment * _clamp01(entity.task_alignment)
+        + w.user_intent * _clamp01(entity.user_intent)
+        + w.system_state * _clamp01(entity.system_state)
+    )
+
+
+def route_entities(
+    entities: list[AttentionEntity],
+    *,
+    weights: AttentionWeights | None = None,
+    per_category_limit: int = 3,
+    total_limit: int = 24,
+) -> AttentionDecision:
+    if per_category_limit < 1:
+        raise ValueError("per_category_limit must be >= 1")
+    if total_limit < 1:
+        raise ValueError("total_limit must be >= 1")
+
+    scored = [ScoredEntity(entity=e, score=score_entity(e, weights)) for e in entities]
+    ranked = sorted(scored, key=lambda item: (-item.score, item.entity.entity_id))
+
+    banks: dict[AttentionCategory, list[ScoredEntity]] = {
+        "memory": [],
+        "agent": [],
+        "tool": [],
+        "task": [],
+        "user_intent": [],
+        "system_state": [],
+        "input_context": [],
+        "output_context": [],
+    }
+    selected: list[ScoredEntity] = []
+    for item in ranked:
+        bank = banks[item.entity.category]
+        if len(bank) >= per_category_limit:
+            continue
+        if len(selected) >= total_limit:
+            break
+        bank.append(item)
+        selected.append(item)
+
+    trajectory = {
+        category: (sum(s.score for s in items) / len(items) if items else 0.0)
+        for category, items in banks.items()
+    }
+    return AttentionDecision(
+        ranked=tuple(ranked),
+        selected=tuple(selected),
+        banks={k: tuple(v) for k, v in banks.items()},
+        trajectory=trajectory,
+    )
+
+
+def persist_ip_as_binary(ip: str, output_path: str | Path) -> Path:
+    address = ipaddress.ip_address(ip)
+    out = Path(output_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_bytes(address.packed)
+    return out
+
+
+def hash_binary_with_brain_metadata(binary_path: str | Path, brain_md_path: str | Path) -> dict[str, Any]:
+    binary_file = Path(binary_path)
+    brain_file = Path(brain_md_path)
+    payload = binary_file.read_bytes()
+    brain_text = brain_file.read_text(encoding="utf-8")
+
+    file_meta = {
+        "binary_file": str(binary_file),
+        "binary_size": len(payload),
+        "brain_file": str(brain_file),
+        "brain_chars": len(brain_text),
+    }
+    metadata_bytes = json.dumps(file_meta, sort_keys=True).encode("utf-8")
+
+    binary_hash = hashlib.sha256(payload).hexdigest()
+    brain_hash = hashlib.sha256(brain_text.encode("utf-8")).hexdigest()
+
+    combined = hashlib.sha256()
+    combined.update(payload)
+    combined.update(metadata_bytes)
+    combined.update(brain_text.encode("utf-8"))
+    combined_hash = combined.hexdigest()
+
+    return {
+        "binary_sha256": binary_hash,
+        "brain_sha256": brain_hash,
+        "combined_sha256": combined_hash,
+        "metadata": file_meta,
+    }
+
+
+async def ping_local_model(base_url: str = "http://127.0.0.1:1234/v1", timeout_s: float = 2.0) -> dict[str, Any]:
+    url = f"{base_url.rstrip('/')}/models"
+    async with httpx.AsyncClient(timeout=timeout_s) as client:
+        resp = await client.get(url)
+        resp.raise_for_status()
+        data = resp.json()
+    models = [m.get("id", "") for m in data.get("data", []) if isinstance(m, dict)]
+    return {"ok": True, "url": url, "models": models, "raw": data}
+
+
+async def request_structured_response(
+    prompt: str,
+    *,
+    base_url: str = "http://127.0.0.1:1234/v1",
+    model: str | None = None,
+    timeout_s: float = 30.0,
+) -> dict[str, Any]:
+    url = f"{base_url.rstrip('/')}/chat/completions"
+    selected_model = model
+    if not selected_model:
+        model_probe = await ping_local_model(base_url=base_url, timeout_s=timeout_s)
+        models = model_probe.get("models", [])
+        if not models:
+            raise RuntimeError("no models available at local endpoint")
+        selected_model = str(models[0])
+
+    body = {
+        "model": selected_model,
+        "messages": [
+            {
+                "role": "system",
+                "content": (
+                    "Respond with strict JSON containing keys: summary, confidence, "
+                    "routing_recommendation, and safety_notes."
+                ),
+            },
+            {"role": "user", "content": prompt},
+        ],
+        "temperature": 0.2,
+        "response_format": {"type": "json_object"},
+    }
+    async with httpx.AsyncClient(timeout=timeout_s) as client:
+        resp = await client.post(url, json=body)
+        if resp.status_code >= 400:
+            # Some local hosts/models reject `response_format`; retry with plain request.
+            fallback = dict(body)
+            fallback.pop("response_format", None)
+            resp = await client.post(url, json=fallback)
+        resp.raise_for_status()
+        data = resp.json()
+    text = data["choices"][0]["message"]["content"]
+    parsed = _parse_json_from_text(text)
+    return {"ok": True, "url": url, "model": selected_model, "response": parsed, "raw_text": text}
+
+
+def _parse_json_from_text(text: str) -> dict[str, Any]:
+    try:
+        out = json.loads(text)
+        if isinstance(out, dict):
+            return out
+    except json.JSONDecodeError:
+        pass
+    start = text.find("{")
+    end = text.rfind("}")
+    if 0 <= start < end:
+        try:
+            out = json.loads(text[start : end + 1])
+            if isinstance(out, dict):
+                return out
+        except json.JSONDecodeError:
+            pass
+    return {"summary": text.strip(), "confidence": 0.0, "routing_recommendation": [], "safety_notes": "unparsed"}
+
+
+def _parse_entities_json(path: str | Path) -> list[AttentionEntity]:
+    raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(raw, list):
+        raise ValueError("entities JSON must be a list")
+    out: list[AttentionEntity] = []
+    for item in raw:
+        out.append(
+            AttentionEntity(
+                entity_id=str(item["entity_id"]),
+                category=item["category"],
+                payload=dict(item.get("payload", {})),
+                semantic_relevance=float(item.get("semantic_relevance", 0.0)),
+                recency=float(item.get("recency", 0.0)),
+                task_alignment=float(item.get("task_alignment", 0.0)),
+                user_intent=float(item.get("user_intent", 0.0)),
+                system_state=float(item.get("system_state", 0.0)),
+            )
+        )
+    return out
+
+
+def _main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Attention network utility for atulya-cortex/plasticity.")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    ip_cmd = sub.add_parser("ip-hash", help="Persist IP as binary and hash with BRAIN.md metadata.")
+    ip_cmd.add_argument("--ip", required=True)
+    ip_cmd.add_argument("--binary-path", required=True)
+    ip_cmd.add_argument("--brain-md", required=True)
+
+    route_cmd = sub.add_parser("route", help="Score and route entities from a JSON file.")
+    route_cmd.add_argument("--entities-json", required=True)
+    route_cmd.add_argument("--per-category-limit", type=int, default=3)
+    route_cmd.add_argument("--total-limit", type=int, default=24)
+
+    ping_cmd = sub.add_parser("ping-model", help="Ping local model host /v1/models endpoint.")
+    ping_cmd.add_argument("--base-url", default="http://127.0.0.1:1234/v1")
+
+    ask_cmd = sub.add_parser("ask-model", help="Request structured JSON from local model host.")
+    ask_cmd.add_argument("--base-url", default="http://127.0.0.1:1234/v1")
+    ask_cmd.add_argument("--model", default="")
+    ask_cmd.add_argument("--prompt", required=True)
+
+    args = parser.parse_args(argv)
+
+    if args.cmd == "ip-hash":
+        binary_path = persist_ip_as_binary(args.ip, args.binary_path)
+        digest = hash_binary_with_brain_metadata(binary_path, args.brain_md)
+        print(json.dumps({"binary_path": str(binary_path), **digest}, indent=2))
+        return 0
+    if args.cmd == "route":
+        entities = _parse_entities_json(args.entities_json)
+        decision = route_entities(
+            entities,
+            per_category_limit=args.per_category_limit,
+            total_limit=args.total_limit,
+        )
+        payload = {
+            "selected": [
+                {
+                    "entity_id": item.entity.entity_id,
+                    "category": item.entity.category,
+                    "score": round(item.score, 6),
+                }
+                for item in decision.selected
+            ],
+            "trajectory": {k: round(v, 6) for k, v in decision.trajectory.items()},
+        }
+        print(json.dumps(payload, indent=2))
+        return 0
+    if args.cmd == "ping-model":
+        print(json.dumps(asyncio.run(ping_local_model(base_url=args.base_url)), indent=2))
+        return 0
+    if args.cmd == "ask-model":
+        result = asyncio.run(
+            request_structured_response(
+                args.prompt,
+                base_url=args.base_url,
+                model=args.model or None,
+            )
+        )
+        print(json.dumps(result, indent=2))
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())
+

--- a/atulya-cortex/scripts/attention_network_local_test.sh
+++ b/atulya-cortex/scripts/attention_network_local_test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# attention_network_local_test.sh
+# End-to-end smoke test for the attention network utilities.
+#
+# What this script checks:
+# 1) Local model host reachability at localhost:1234 (/v1/models)
+# 2) Structured JSON response generation from /v1/chat/completions
+# 3) IP -> binary persistence + BRAIN.md metadata hashing
+# 4) Deterministic routing over 8 attention categories
+#
+# Guardrail / limitation notes:
+# - This is a transport-level and schema-level smoke test, not a security proof.
+# - "Jailbreak resistance" is partial by design here; we only assert structured
+#   output shape and deterministic routing behavior.
+# - Strong prompt-injection hardening should be implemented at policy/middleware
+#   level in the caller before tool execution.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK_DIR="${ROOT_DIR}/.tmp_attention_network"
+mkdir -p "${WORK_DIR}"
+
+BRAIN_MD="${ROOT_DIR}/../BRAIN.md"
+IP_BIN="${WORK_DIR}/host_ip.bin"
+ENTITIES_JSON="${WORK_DIR}/entities.json"
+
+cat > "${ENTITIES_JSON}" <<'EOF'
+[
+  {"entity_id":"mem-1","category":"memory","semantic_relevance":0.95,"recency":0.80,"task_alignment":0.90,"user_intent":0.80,"system_state":0.60},
+  {"entity_id":"tool-1","category":"tool","semantic_relevance":0.90,"recency":0.60,"task_alignment":0.92,"user_intent":0.82,"system_state":0.80},
+  {"entity_id":"agent-1","category":"agent","semantic_relevance":0.85,"recency":0.50,"task_alignment":0.95,"user_intent":0.75,"system_state":0.70},
+  {"entity_id":"task-1","category":"task","semantic_relevance":0.88,"recency":0.90,"task_alignment":0.96,"user_intent":0.85,"system_state":0.88},
+  {"entity_id":"intent-1","category":"user_intent","semantic_relevance":0.99,"recency":0.70,"task_alignment":0.80,"user_intent":1.00,"system_state":0.60},
+  {"entity_id":"state-1","category":"system_state","semantic_relevance":0.72,"recency":0.95,"task_alignment":0.75,"user_intent":0.60,"system_state":1.00},
+  {"entity_id":"input-1","category":"input_context","semantic_relevance":0.77,"recency":0.40,"task_alignment":0.82,"user_intent":0.88,"system_state":0.72},
+  {"entity_id":"output-1","category":"output_context","semantic_relevance":0.80,"recency":0.30,"task_alignment":0.81,"user_intent":0.70,"system_state":0.65}
+]
+EOF
+
+echo "[1/4] Ping local model server..."
+uv run python plasticity/attention_network.py ping-model --base-url "http://127.0.0.1:1234/v1" | tee "${WORK_DIR}/ping.json"
+
+echo "[2/4] Request structured response..."
+uv run python plasticity/attention_network.py ask-model \
+  --base-url "http://127.0.0.1:1234/v1" \
+  --prompt "Return a compact operational recommendation for cortex attention routing." \
+  | tee "${WORK_DIR}/structured_response.json"
+
+echo "[3/4] Persist binary IP and hash with BRAIN metadata..."
+uv run python plasticity/attention_network.py ip-hash \
+  --ip "127.0.0.1" \
+  --binary-path "${IP_BIN}" \
+  --brain-md "${BRAIN_MD}" \
+  | tee "${WORK_DIR}/ip_hash.json"
+
+echo "[4/4] Route entities deterministically..."
+uv run python plasticity/attention_network.py route \
+  --entities-json "${ENTITIES_JSON}" \
+  --per-category-limit 1 \
+  --total-limit 8 \
+  | tee "${WORK_DIR}/route.json"
+
+echo "Attention-network smoke test complete."
+echo "Artifacts: ${WORK_DIR}"
+

--- a/atulya-cortex/tests/test_attention_network.py
+++ b/atulya-cortex/tests/test_attention_network.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from plasticity.attention_network import (
+    AttentionEntity,
+    AttentionWeights,
+    hash_binary_with_brain_metadata,
+    ping_local_model,
+    request_structured_response,
+    route_entities,
+    score_entity,
+)
+
+
+def test_score_entity_uses_weighted_formula() -> None:
+    entity = AttentionEntity(
+        entity_id="m1",
+        category="memory",
+        semantic_relevance=1.0,
+        recency=0.5,
+        task_alignment=0.5,
+        user_intent=0.2,
+        system_state=0.0,
+    )
+    w = AttentionWeights(semantic_relevance=0.4, recency=0.2, task_alignment=0.2, user_intent=0.1, system_state=0.1)
+    assert score_entity(entity, w) == pytest.approx(0.62)
+
+
+def test_route_entities_is_deterministic_and_category_capped() -> None:
+    entities = [
+        AttentionEntity(entity_id="memory-2", category="memory", semantic_relevance=0.3, recency=0.2, task_alignment=0.2),
+        AttentionEntity(entity_id="memory-1", category="memory", semantic_relevance=0.9, recency=0.9, task_alignment=0.9),
+        AttentionEntity(entity_id="memory-3", category="memory", semantic_relevance=0.8, recency=0.8, task_alignment=0.8),
+        AttentionEntity(entity_id="tool-1", category="tool", semantic_relevance=0.95, recency=0.9, task_alignment=0.9),
+    ]
+    decision = route_entities(entities, per_category_limit=2, total_limit=3)
+
+    # Highest-scoring tool + top two memories should survive.
+    assert [s.entity.entity_id for s in decision.selected] == ["tool-1", "memory-1", "memory-3"]
+    assert len(decision.banks["memory"]) == 2
+    assert len(decision.banks["tool"]) == 1
+    assert decision.trajectory["agent"] == 0.0
+
+
+def test_hash_binary_with_brain_metadata(tmp_path: Path) -> None:
+    binary = tmp_path / "ip.bin"
+    binary.write_bytes(b"\x7f\x00\x00\x01")
+    brain = tmp_path / "BRAIN.md"
+    brain.write_text("# cortex\nmetadata\n", encoding="utf-8")
+
+    digest = hash_binary_with_brain_metadata(binary, brain)
+    assert set(digest) == {"binary_sha256", "brain_sha256", "combined_sha256", "metadata"}
+    assert digest["metadata"]["binary_size"] == 4
+    assert digest["metadata"]["brain_chars"] > 0
+
+
+@pytest.mark.asyncio
+async def test_ping_local_model_reads_models(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path.endswith("/models")
+        return httpx.Response(200, json={"data": [{"id": "google/gemma-3-4b"}]})
+
+    transport = httpx.MockTransport(handler)
+
+    class _FakeAsyncClient(httpx.AsyncClient):
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr("plasticity.attention_network.httpx.AsyncClient", _FakeAsyncClient)
+    out = await ping_local_model()
+    assert out["ok"] is True
+    assert "google/gemma-3-4b" in out["models"]
+
+
+@pytest.mark.asyncio
+async def test_request_structured_response_parses_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path.endswith("/chat/completions")
+        payload = {
+            "choices": [
+                {
+                    "message": {
+                        "content": json.dumps(
+                            {
+                                "summary": "ok",
+                                "confidence": 0.9,
+                                "routing_recommendation": ["memory", "tool"],
+                                "safety_notes": "none",
+                            }
+                        )
+                    }
+                }
+            ]
+        }
+        return httpx.Response(200, json=payload)
+
+    transport = httpx.MockTransport(handler)
+
+    class _FakeAsyncClient(httpx.AsyncClient):
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr("plasticity.attention_network.httpx.AsyncClient", _FakeAsyncClient)
+    out = await request_structured_response("hello", model="google/gemma-3-4b")
+    assert out["response"]["summary"] == "ok"
+

--- a/atulya-cortex/tests/test_cortex_loop.py
+++ b/atulya-cortex/tests/test_cortex_loop.py
@@ -28,6 +28,9 @@ from cortex import (
     Stimulus,
     Utterance,
 )
+from cortex.peer_banks import peer_bank_id
+from cortex.plasticity_prompt_memory import PlasticityPromptMemory, PlasticityPromptSettings
+from cortex.self_healing import SelfHealingEngine, SelfHealingSettings
 
 # ---------------------------------------------------------------------------
 # Personality
@@ -273,6 +276,38 @@ class _StubLanguage:
         )
 
 
+class _SequenceLanguage:
+    """Returns a sequence of canned outputs across think() calls."""
+
+    def __init__(self, outputs: list[str]) -> None:
+        self._outputs = list(outputs)
+        self.calls = 0
+
+    async def think(self, messages: list[dict[str, Any]], **kwargs: Any) -> Utterance:
+        self.calls += 1
+        text = self._outputs.pop(0) if self._outputs else ""
+        return Utterance(
+            text=text,
+            provider="stub",
+            model="stub-model",
+            elapsed_ms=1.0,
+            usage={"total_tokens": 0},
+            raw={},
+        )
+
+
+class _StubGenomeLanguage:
+    async def think(self, messages: list[dict[str, Any]], **kwargs: Any) -> Utterance:
+        return Utterance(
+            text='{"genome":"- Prioritize concise, grounded replies\\n- State execution limits clearly\\n- Ask clarifying questions only when needed"}',
+            provider="stub",
+            model="stub-model",
+            elapsed_ms=1.0,
+            usage={"total_tokens": 0},
+            raw={},
+        )
+
+
 class TestCortexRealLoop:
     @pytest.mark.asyncio
     async def test_echo_mode_when_no_language(self) -> None:
@@ -356,6 +391,177 @@ class TestCortexRealLoop:
         cortex = Cortex(language=lang)
         text = await cortex.reflect_text(Stimulus(channel="tui:a", sender="a", text="x"))
         assert text == "just text"
+
+    @pytest.mark.asyncio
+    async def test_peer_bank_mental_model_is_injected_for_remote_peer(self) -> None:
+        class _StubPeerMemory:
+            def __init__(self) -> None:
+                self.ensure_calls: list[str] = []
+                self.prompt_calls: list[str] = []
+
+            async def ensure_bank(self, bank_id: str) -> None:
+                self.ensure_calls.append(bank_id)
+
+            async def bank_mental_model_prompt(self, bank_id: str, **_kwargs: Any) -> str:
+                self.prompt_calls.append(bank_id)
+                return "Peer bank mental model (primary guidance for this peer):\n- style: concise and practical"
+
+            async def retain_turn(self, *_args: Any, **_kwargs: Any) -> None:
+                return None
+
+        lang = _StubLanguage(reply="model-reply")
+        peer_memory = _StubPeerMemory()
+        cortex = Cortex(
+            language=lang,
+            peer_memory=peer_memory,  # type: ignore[arg-type]
+            cortex_profile="default",
+            peer_bank_channels=frozenset({"whatsapp"}),
+        )
+        peer = "25550001111@s.whatsapp.net"
+        await cortex.reflect(
+            Stimulus(channel="whatsapp:25550001111@s.whatsapp.net", sender=peer, text="hi"),
+            peer_key=peer,
+        )
+
+        expected_bank = peer_bank_id("default", peer)
+        assert peer_memory.ensure_calls == [expected_bank]
+        assert peer_memory.prompt_calls == [expected_bank]
+        assert lang.last_messages is not None
+        sys_msg = lang.last_messages[0]["content"]
+        assert "Peer bank mental model (primary guidance for this peer):" in sys_msg
+        assert "concise and practical" in sys_msg
+
+    @pytest.mark.asyncio
+    async def test_global_self_healing_repairs_empty_reply_with_judge(self, tmp_path: Path) -> None:
+        lang = _SequenceLanguage(
+            [
+                "",
+                '{"verdict":"repair","repaired_reply":"Recovered reply from self-heal","confidence":0.93,"notes":"ok"}',
+            ]
+        )
+        heal = SelfHealingEngine(
+            SelfHealingSettings(enabled=True, max_retries=1, judge_enabled=True),
+            telemetry_file=tmp_path / "self-healing.jsonl",
+        )
+        cortex = Cortex(language=lang, self_healing=heal)
+        intent = await cortex.reflect(Stimulus(channel="whatsapp:a", sender="a", text="hello?"))
+        assert intent.action.payload["text"] == "Recovered reply from self-heal"
+        assert lang.calls == 2
+        lines = (tmp_path / "self-healing.jsonl").read_text(encoding="utf-8").strip().splitlines()
+        assert lines
+        assert "healed" in lines[-1]
+
+    @pytest.mark.asyncio
+    async def test_global_self_healing_fallback_when_judge_disabled(self) -> None:
+        lang = _SequenceLanguage([""])
+        heal = SelfHealingEngine(
+            SelfHealingSettings(
+                enabled=True,
+                max_retries=1,
+                judge_enabled=False,
+                fallback_text="fallback-from-healer",
+            )
+        )
+        cortex = Cortex(language=lang, self_healing=heal)
+        intent = await cortex.reflect(Stimulus(channel="whatsapp:a", sender="a", text="hello?"))
+        assert intent.action.payload["text"] == "fallback-from-healer"
+        assert lang.calls == 1
+
+    @pytest.mark.asyncio
+    async def test_global_self_healing_repairs_tool_payload_leak_by_intent(self) -> None:
+        lang = _SequenceLanguage(['{"command":"nvidia-smi"}'])
+        heal = SelfHealingEngine(SelfHealingSettings(enabled=True, judge_enabled=False))
+        cortex = Cortex(language=lang, self_healing=heal)
+        intent = await cortex.reflect(
+            Stimulus(
+                channel="whatsapp:25550001111@s.whatsapp.net",
+                sender="25550001111@s.whatsapp.net",
+                text="can you run nvidia-smi and check gpu temp?",
+            )
+        )
+        text = str(intent.action.payload["text"]).lower()
+        assert "execute" in text
+        assert "cannot run tools directly on whatsapp" in text
+        assert lang.calls == 1
+
+    @pytest.mark.asyncio
+    async def test_plasticity_learns_guidance_and_injects_time_context(self, tmp_path: Path) -> None:
+        mem = PlasticityPromptMemory(
+            tmp_path / "prompt-memory.json",
+            PlasticityPromptSettings(enabled=True, per_user_enabled=True, system_enabled=True, time_context_enabled=True),
+        )
+        lang = _StubLanguage(reply="ok")
+        cortex = Cortex(language=lang, plasticity=mem)
+        peer = "25550001111@s.whatsapp.net"
+        await cortex.reflect(
+            Stimulus(channel=f"whatsapp:{peer}", sender=peer, text="please be concise and no emoji"),
+            peer_key=peer,
+        )
+        await cortex.reflect(
+            Stimulus(channel=f"whatsapp:{peer}", sender=peer, text="hi again"),
+            peer_key=peer,
+        )
+        assert lang.last_messages is not None
+        sys_msg = str(lang.last_messages[0]["content"])
+        assert "Adaptive peer guidance:" in sys_msg
+        assert "Keep replies concise." in sys_msg
+        assert "Avoid emojis unless asked." in sys_msg
+        assert "Time context:" in sys_msg
+        assert "now_utc:" in sys_msg
+
+    @pytest.mark.asyncio
+    async def test_plasticity_distills_prompt_genome_and_supports_rollback(self, tmp_path: Path) -> None:
+        mem = PlasticityPromptMemory(
+            tmp_path / "prompt-memory.json",
+            PlasticityPromptSettings(
+                enabled=True,
+                per_user_enabled=True,
+                system_enabled=True,
+                distill_enabled=True,
+                distill_min_updates=1,
+                distill_cooldown_s=0.0,
+                distill_max_versions=4,
+            ),
+        )
+        peer = "25550001111@s.whatsapp.net"
+        mem.record_turn(peer_key=peer, user_text="be concise and no emoji", assistant_text="ok")
+        await mem.distill_if_due(
+            language=_StubGenomeLanguage(),
+            provider=None,
+            model=None,
+            temperature=0.1,
+            max_tokens=128,
+            peer_key=peer,
+        )
+        block = mem.prompt_block(peer_key=peer)
+        assert "System prompt genome:" in block
+        assert "Peer prompt genome:" in block
+        assert "Prioritize concise, grounded replies" in block
+
+        # Distill a second time with a modified language output to create version 2.
+        class _StubGenomeLanguageV2:
+            async def think(self, messages: list[dict[str, Any]], **kwargs: Any) -> Utterance:
+                return Utterance(
+                    text='{"genome":"- Keep answers concise\\n- Prefer direct next actions"}',
+                    provider="stub",
+                    model="stub-model",
+                    elapsed_ms=1.0,
+                    usage={"total_tokens": 0},
+                    raw={},
+                )
+
+        mem.record_turn(peer_key=peer, user_text="be concise", assistant_text="ok")
+        await mem.distill_if_due(
+            language=_StubGenomeLanguageV2(),
+            provider=None,
+            model=None,
+            temperature=0.1,
+            max_tokens=128,
+            peer_key=peer,
+        )
+        assert "Prefer direct next actions" in mem.prompt_block(peer_key=peer)
+        assert mem.rollback(peer_key=peer) is True
+        assert "Prioritize concise, grounded replies" in mem.prompt_block(peer_key=peer)
 
 
 # ---------------------------------------------------------------------------

--- a/atulya-cortex/tests/test_home_config.py
+++ b/atulya-cortex/tests/test_home_config.py
@@ -94,6 +94,8 @@ class TestCortexHome:
         # caches & whatsapp session stay shared regardless of profile
         assert home.llm_cache_dir == tmp_path / "cache" / "llm"
         assert home.whatsapp_session_dir == tmp_path / "whatsapp" / "session"
+        assert home.whatsapp_mental_models_dir == tmp_path / "whatsapp" / "mental-models"
+        assert home.whatsapp_memory_raw_dir == tmp_path / "whatsapp" / "memory-raw"
         assert home.dashboard_lock == tmp_path / "dashboard.lock"
 
     def test_bootstrap_creates_all_dirs_idempotently(self, tmp_path):
@@ -109,6 +111,8 @@ class TestCortexHome:
             tmp_path / "cache" / "llm",
             tmp_path / "cache" / "embedding",
             tmp_path / "whatsapp" / "session",
+            tmp_path / "whatsapp" / "mental-models",
+            tmp_path / "whatsapp" / "memory-raw",
             tmp_path / "logs",
             tmp_path / "profiles",
         ):

--- a/atulya-cortex/tests/test_peer_bank_cli.py
+++ b/atulya-cortex/tests/test_peer_bank_cli.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import json
+import types
+
+from cortex import config as config_module
+from cortex.cli import main as cli_main
+from cortex.home import ENV_HOME, ENV_PROFILE, CortexHome
+
+
+class _Model:
+    def __init__(self, model_id: str, name: str, content: str) -> None:
+        self.id = model_id
+        self.name = name
+        self.content = content
+
+
+class _ListResult:
+    def __init__(self, items):
+        self.items = items
+
+
+class _FakeMentalModels:
+    def __init__(self, store):
+        self._store = store
+        self._counter = 0
+
+    def list(self, bank_id: str):
+        return _ListResult(list(self._store.setdefault(bank_id, [])))
+
+    def create(self, bank_id: str, name: str, content: str, tags=None):
+        self._counter += 1
+        m = _Model(f"m-{self._counter}", name, content)
+        self._store.setdefault(bank_id, []).append(m)
+        return m
+
+    def update(self, bank_id: str, mental_model_id: str, name=None, content=None, tags=None):
+        for m in self._store.setdefault(bank_id, []):
+            if m.id == mental_model_id:
+                if name is not None:
+                    m.name = name
+                if content is not None:
+                    m.content = content
+                return m
+        raise KeyError(mental_model_id)
+
+
+class _FakeBanks:
+    def create(self, bank_id: str, name=None, mission=None, disposition=None):
+        return {"id": bank_id}
+
+
+class _FakeEmbedded:
+    _store = {}
+
+    def __init__(self, profile="default", **kwargs):
+        self.profile = profile
+        self.mental_models = _FakeMentalModels(_FakeEmbedded._store)
+        self.banks = _FakeBanks()
+
+    def close(self, stop_daemon: bool = False):
+        return None
+
+
+def test_peer_bank_set_get_and_resolve(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv(ENV_HOME, str(tmp_path / "home"))
+    monkeypatch.delenv(ENV_PROFILE, raising=False)
+    home = CortexHome.resolve(root=tmp_path / "home").bootstrap()
+    config_module.seed(home)
+
+    fake_mod = types.SimpleNamespace(AtulyaEmbedded=_FakeEmbedded, AtulyaClient=_FakeEmbedded)
+    monkeypatch.setitem(__import__("sys").modules, "atulya", fake_mod)
+
+    rc = cli_main(
+        [
+            "peer-bank",
+            "--home",
+            str(home.root),
+            "set",
+            "whatsapp:255@lid",
+            "--name",
+            "peer_profile",
+            "--content",
+            "User prefers short bullet answers",
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "created peer_profile" in out
+    mirror = home.whatsapp_mental_models_dir / "255.json"
+    assert mirror.exists()
+    first = json.loads(mirror.read_text(encoding="utf-8"))
+    assert first["peer_key"] == "255@lid"
+    assert first["bank_id"].startswith("cortex_default_")
+    assert first["mental_models"][0]["name"] == "peer_profile"
+    assert "top_entities" in first
+    assert "top_entities_hash" in first
+    assert any(d.get("change") == "created" for d in first["delta"])
+
+    rc = cli_main(
+        [
+            "peer-bank",
+            "--home",
+            str(home.root),
+            "set",
+            "whatsapp:255@lid",
+            "--name",
+            "peer_profile",
+            "--content",
+            "User now prefers long-form explanations",
+        ]
+    )
+    assert rc == 0
+    second = json.loads(mirror.read_text(encoding="utf-8"))
+    assert second["mental_models"][0]["content"] == "User now prefers long-form explanations"
+    assert any(d.get("change") == "updated" for d in second["delta"])
+
+    rc = cli_main(
+        [
+            "peer-bank",
+            "--home",
+            str(home.root),
+            "get",
+            "whatsapp:255@lid",
+            "--name",
+            "peer_profile",
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "peer_profile" in out
+    assert "long-form explanations" in out
+
+    rc = cli_main(["peer-bank", "--home", str(home.root), "resolve", "whatsapp:255@lid"])
+    assert rc == 0
+    out = capsys.readouterr().out.strip()
+    assert out.startswith("cortex_default_")
+

--- a/atulya-cortex/tests/test_peer_memory_entities.py
+++ b/atulya-cortex/tests/test_peer_memory_entities.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+
+from cortex.peer_memory import PeerMemoryBridge
+
+
+class _FakeMentalModelsAPI:
+    def list(self, bank_id: str):
+        return type("R", (), {"items": []})()
+
+
+class _FakeMemoriesAPI:
+    def __init__(self, items):
+        self._items = items
+
+    def list(self, bank_id: str, memory_type=None, search_query=None, limit=100, offset=0):
+        return __import__("builtins").type("R", (), {"items": list(self._items)})()
+
+
+class _FakeEmbedded:
+    def __init__(self, items):
+        self.mental_models = _FakeMentalModelsAPI()
+        self.memories = _FakeMemoriesAPI(items)
+
+    async def acreate_bank(self, bank_id: str, retain_mission: str = ""):
+        return None
+
+
+class _NoopHip:
+    async def encode(self, *args, **kwargs):
+        return None
+
+
+class _NoopRecall:
+    async def recall(self, *args, **kwargs):
+        return []
+
+
+@pytest.mark.asyncio
+async def test_top_used_entities_capped_at_88_and_sorted_by_usage() -> None:
+    items = []
+    for i in range(120):
+        items.append(
+            {
+                "id": f"mem-{i}",
+                "type": "semantic",
+                "content": f"entity {i}",
+                "usage_count": i,
+            }
+        )
+    bridge = PeerMemoryBridge(
+        embedded=_FakeEmbedded(items),
+        hippocampus=_NoopHip(),
+        recall=_NoopRecall(),
+        recall_top_k=4,
+    )
+    top = await bridge._top_used_bank_entities("bank-a", limit=88)
+    assert len(top) == 88
+    assert top[0].entity_id == "mem-119"
+    assert top[-1].entity_id == "mem-32"
+

--- a/atulya-cortex/tests/test_peer_memory_raw_backup.py
+++ b/atulya-cortex/tests/test_peer_memory_raw_backup.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cortex.bus import Recollection, Stimulus
+from cortex.peer_memory import PeerMemoryBridge
+
+
+class _Embedded:
+    async def acreate_bank(self, bank_id: str, retain_mission: str = ""):
+        return None
+
+    async def aretain(self, **kwargs):
+        return {"ok": True}
+
+
+class _Hip:
+    async def encode(self, *args, **kwargs):
+        return {"ok": True}
+
+
+class _Rec:
+    async def recall(self, *args, **kwargs):
+        return [
+            Recollection(kind="episodic", text="hello from memory", score=0.9, source="mem-1"),
+        ]
+
+
+@pytest.mark.asyncio
+async def test_recall_and_retain_write_raw_backup(tmp_path: Path) -> None:
+    bridge = PeerMemoryBridge(
+        embedded=_Embedded(),
+        hippocampus=_Hip(),
+        recall=_Rec(),
+        recall_top_k=4,
+        whatsapp_memory_raw_dir=tmp_path,
+    )
+    bank = "cortex_default_test_peer"
+    out = await bridge.cortex_recall("hello", "episodic", bank)
+    assert out and out[0].text == "hello from memory"
+
+    stim = Stimulus(channel="whatsapp:test", sender="test", text="hello")
+    await bridge.retain_turn(stim, "hi", "there", bank)
+
+    files = list(tmp_path.glob("*.jsonl"))
+    assert files, "expected raw backup file"
+    body = files[0].read_text(encoding="utf-8").strip().splitlines()
+    events = [json.loads(line)["event"] for line in body]
+    assert "recall" in events
+    assert "retain" in events
+

--- a/atulya-cortex/tests/test_setup_wizard.py
+++ b/atulya-cortex/tests/test_setup_wizard.py
@@ -164,7 +164,8 @@ class TestRunPersona:
 class TestRunBank:
     def test_no_token_path(self, home):
         prompter = ScriptedPrompter(
-            answers=["my-bank", "http://localhost:8000"],
+            answers=["my-bank", "http://localhost:8888"],
+            choices=["api"],
             yes_nos=[False],
         )
         wizard = SetupWizard(home, prompter, probe_fn=_mock_probe())
@@ -172,11 +173,13 @@ class TestRunBank:
         assert result.ok
         cfg = config_module.load(home)
         assert cfg.memory.bank_id == "my-bank"
+        assert cfg.memory.peer_banks_backend == "api"
         assert result.secrets_recorded == []
 
     def test_with_token_path(self, home):
         prompter = ScriptedPrompter(
             answers=["my-bank", "http://api.local:8000", "ATULYA_API_KEY"],
+            choices=["embedded"],
             yes_nos=[True],
             secrets=["secret-token"],
         )
@@ -301,12 +304,12 @@ class TestRunAll:
         # home  -> 0 prompts
         # model -> 1 choice, 2 answers (lm_studio base_url, model)
         # persona -> 4 answers (operator, brain, voice, traits) — no overwrite prompt because persona file does not exist yet
-        # bank -> 2 answers (bank_id, api_url), 1 yes_no (no token)
+        # bank -> 2 answers (bank_id, api_url), 1 choice (backend), 1 yes_no (no token)
         # skills -> 0 prompts
         # telegram -> 1 yes_no (disable)
         # whatsapp -> 1 yes_no (disable)
         prompter = ScriptedPrompter(
-            choices=["lm_studio"],
+            choices=["lm_studio", "embedded"],
             answers=[
                 "http://localhost:1234/v1",
                 "google/gemma-3-4b",
@@ -315,7 +318,7 @@ class TestRunAll:
                 "warm but terse",
                 "curious, practical, honest",
                 "atulya-cortex",
-                "http://localhost:8000",
+                "http://localhost:8888",
             ],
             yes_nos=[False, False, False],
         )

--- a/atulya-cortex/tests/test_whatsapp_cli.py
+++ b/atulya-cortex/tests/test_whatsapp_cli.py
@@ -362,3 +362,81 @@ class TestWhatsAppStart:
         assert env is not None
         assert env.get("CORTEX_WA_AUTH_DIR", "").endswith("whatsapp/session")
         assert constructor_calls[0]["stderr_sink"] is not None
+
+    def test_start_retries_when_cortex_returns_empty_reply(self, home, monkeypatch):
+        delivered: list[tuple[str, str]] = []
+
+        class FakeBackend:
+            def __init__(self, *, bridge_command, bridge_url, cwd=None, env=None, stderr_sink=None):
+                self._sink = None
+                self._fed = False
+
+            async def start(self, sink):
+                self._sink = sink
+
+                async def _push():
+                    await asyncio.sleep(0)
+                    if not self._fed and self._sink:
+                        self._fed = True
+                        from sensors.whatsapp import WhatsAppEar
+
+                        await self._sink(
+                            Stimulus(
+                                channel=WhatsAppEar.channel_for_jid("111@s.whatsapp.net"),
+                                sender="111@s.whatsapp.net",
+                                text="test self-heal",
+                                raw={"from": "111@s.whatsapp.net", "body": "test self-heal"},
+                            )
+                        )
+
+                asyncio.create_task(_push())
+
+            async def stop(self):
+                self._sink = None
+
+            async def send(self, jid, text):
+                delivered.append((jid, text))
+
+        class FakeCortex:
+            def __init__(self):
+                self.calls = 0
+
+            async def reflect(self, stim, *, reflex, peer_key=None):
+                self.calls += 1
+                if self.calls == 1:
+                    from cortex.bus import Intent
+
+                    return Intent(action=Action(kind="reply", payload={"text": ""}), channel=stim.channel, sender=stim.sender)
+                from cortex.bus import Intent
+
+                return Intent(action=Action(kind="reply", payload={"text": "recovered reply"}), channel=stim.channel, sender=stim.sender)
+
+        fake_cortex = FakeCortex()
+        monkeypatch.setattr(wa_module, "_node_available", lambda: True)
+
+        async def short_pump(ear, router):
+            async for stim in ear.perceive():
+                await router.route(stim)
+                return
+
+        monkeypatch.setattr(wa_module, "_pump_stimuli", short_pump)
+
+        with (
+            patch("sensors.whatsapp.BaileysBackend", FakeBackend),
+            patch("cortex._runtime.build_cortex_from_config", lambda *args, **kwargs: fake_cortex),
+        ):
+            rc = cli_main(
+                [
+                    "whatsapp",
+                    "--home",
+                    str(home.root),
+                    "start",
+                    "--default-allow",
+                    "--echo",
+                    "--bridge-cmd",
+                    "node /tmp/fake.js",
+                ]
+            )
+        assert rc == 0
+        assert delivered == [("111@s.whatsapp.net", "recovered reply")]
+        assert fake_cortex.calls == 2


### PR DESCRIPTION
## Summary
- Add a production-grade global self-healing layer that detects empty/invalid/tool-payload-leak replies, retries safely, and records structured telemetry.
- Introduce adaptive plasticity prompt memory with per-user + system-wide directive learning, prompt injection, and optional LLM-based genome distillation with versioned rollback.
- Expand WhatsApp reliability and observability with send retries, explicit failure logging, timestamped flow logs, and stronger peer-memory integration/health checks.
- Add attention-network utilities for deterministic entity routing, local model probing, structured local LLM responses, and binary IP + BRAIN metadata hashing, with smoke script and tests.
- Add peer bank CLI + peer mental model/local mirror/raw backup flows and wire related config/runtime/setup updates.

## Test plan
- [x] `uv run pytest -q tests/test_cortex_loop.py tests/test_home_config.py tests/test_whatsapp_cli.py`
- [x] `uv run pytest -q tests/test_whatsapp_cli.py`
- [x] `uv run pytest -q tests/test_cortex_loop.py tests/test_whatsapp_cli.py tests/test_home_config.py tests/test_setup_wizard.py`
- [x] `uv run pytest -q tests/test_attention_network.py tests/test_peer_bank_cli.py tests/test_peer_memory_entities.py tests/test_peer_memory_raw_backup.py`
- [x] Pre-commit hooks passed during commit (lint.sh)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `Cortex.reflect` prompt/reply path (adds self-healing + adaptive prompt injection) and expands peer-memory backends/logging, which could change response behavior and introduce new failure modes in production loops.
> 
> **Overview**
> Adds **global reply self-healing** to `Cortex.reflect`, running deterministic checks and (optionally) an LLM judge/repair pass with JSONL telemetry, plus a WhatsApp-side retry when a reply comes back empty.
> 
> Introduces **adaptive plasticity prompt memory** that learns directive hints from user turns, injects per-system/per-peer guidance (and optional time context) into the system prompt, and can distill/rollback compact “prompt genomes”.
> 
> Expands **peer-bank/peer-memory** support: selectable `embedded` vs `api` backend, bank-level mental-model prompt injection into conversations, a new `peer-bank` CLI to inspect/update mental models, and optional on-disk mirrors + raw JSONL backups for WhatsApp; WhatsApp loop also gains send retries, timestamped recv/send logs, and a peer-memory startup healthcheck.
> 
> Adds an `attention_network` utility module (routing/scoring + local model probes/structured responses) with a smoke script and tests, and updates config/template/setup defaults (including `memory.api_url` default port and new `self_healing`/`plasticity` sections).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1da98aa35bd2cf53cea22fa00bfaa00990a69d31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->