### PR TITLE
[bugfix] fix consolidation recall-id collisions and add failed-operation retry

### DIFF
--- a/atulya-api/atulya_api/api/http.py
+++ b/atulya-api/atulya_api/api/http.py
@@ -2482,6 +2482,30 @@ class CancelOperationResponse(BaseModel):
     operation_id: str
 
 
+class RetryOperationResponse(BaseModel):
+    """Response model for retry operation endpoint."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "success": True,
+                "message": "Retried operation 550e8400-e29b-41d4-a716-446655440000 as 0196e188-6db5-7f2a-a5f8-f654d2fcb3ad",
+                "operation_id": "0196e188-6db5-7f2a-a5f8-f654d2fcb3ad",
+                "retried_from_operation_id": "550e8400-e29b-41d4-a716-446655440000",
+                "bank_id": "user123",
+                "operation_type": "consolidation",
+            }
+        }
+    )
+
+    success: bool
+    message: str
+    operation_id: str
+    retried_from_operation_id: str
+    bank_id: str
+    operation_type: str | None = None
+
+
 class ChildOperationStatus(BaseModel):
     """Status of a child operation (for batch operations)."""
 
@@ -5019,6 +5043,43 @@ def _register_routes(app: FastAPI):
 
             error_detail = f"{str(e)}\n\nTraceback:\n{traceback.format_exc()}"
             logger.error(f"Error in /v1/default/banks/{bank_id}/operations/{operation_id}: {error_detail}")
+            raise HTTPException(status_code=500, detail=str(e))
+
+    @app.post(
+        "/v1/default/banks/{bank_id}/operations/{operation_id}/retry",
+        response_model=RetryOperationResponse,
+        summary="Retry a failed async operation",
+        description="Create a new pending operation by re-queueing a failed async operation using its original task payload.",
+        operation_id="retry_operation",
+        tags=["Operations"],
+    )
+    async def api_retry_operation(
+        bank_id: str, operation_id: str, request_context: RequestContext = Depends(get_request_context)
+    ):
+        """Retry a failed async operation."""
+        try:
+            try:
+                uuid.UUID(operation_id)
+            except ValueError:
+                raise HTTPException(status_code=400, detail=f"Invalid operation_id format: {operation_id}")
+
+            result = await app.state.memory.retry_failed_operation(
+                bank_id, operation_id, request_context=request_context
+            )
+            return RetryOperationResponse(**result)
+        except ValueError as e:
+            detail = str(e)
+            status = 404 if "not found" in detail.lower() else 400
+            raise HTTPException(status_code=status, detail=detail)
+        except OperationValidationError as e:
+            raise HTTPException(status_code=e.status_code, detail=e.reason)
+        except (AuthenticationError, HTTPException):
+            raise
+        except Exception as e:
+            import traceback
+
+            error_detail = f"{str(e)}\n\nTraceback:\n{traceback.format_exc()}"
+            logger.error(f"Error in /v1/default/banks/{bank_id}/operations/{operation_id}/retry: {error_detail}")
             raise HTTPException(status_code=500, detail=str(e))
 
     @app.get(

--- a/atulya-api/atulya_api/engine/memory_engine.py
+++ b/atulya-api/atulya_api/engine/memory_engine.py
@@ -6230,7 +6230,10 @@ class MemoryEngine(MemoryEngineInterface):
         recall_start = time.time()
 
         # Buffer logs for clean output in concurrent scenarios
-        recall_id = f"{bank_id[:8]}-{int(time.time() * 1000) % 100000}"
+        # Use a high-entropy identifier to avoid collisions across concurrent recalls.
+        # The previous modulo-timestamp format could repeat and break budgeted_operation
+        # registration with "Operation ... already exists".
+        recall_id = f"{bank_id[:8]}-{time.time_ns()}-{uuid.uuid4().hex[:6]}"
         log_buffer = []
         tags_info = f", tags={tags}, tags_match={tags_match}" if tags else ""
         log_buffer.append(
@@ -12106,6 +12109,99 @@ class MemoryEngine(MemoryEngineInterface):
                 "message": f"Operation {operation_id} cancelled",
                 "operation_id": operation_id,
                 "bank_id": bank_id,
+            }
+
+    async def retry_failed_operation(
+        self,
+        bank_id: str,
+        operation_id: str,
+        *,
+        request_context: "RequestContext",
+    ) -> dict[str, Any]:
+        """Re-queue a failed async operation as a new pending operation."""
+        await self._authenticate_tenant(request_context)
+        if self._operation_validator:
+            from atulya_api.extensions import BankWriteContext
+
+            ctx = BankWriteContext(bank_id=bank_id, operation="retry_failed_operation", request_context=request_context)
+            await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
+        pool = await self._get_pool()
+
+        old_op_uuid = uuid.UUID(operation_id)
+        new_op_uuid = uuid.uuid4()
+
+        async with acquire_with_retry(pool) as conn:
+            row = await conn.fetchrow(
+                f"""
+                SELECT operation_id, bank_id, status, operation_type, task_payload, result_metadata
+                FROM {fq_table("async_operations")}
+                WHERE operation_id = $1 AND bank_id = $2
+                """,
+                old_op_uuid,
+                bank_id,
+            )
+            if not row:
+                raise ValueError(f"Operation {operation_id} not found for bank {bank_id}")
+            if row["status"] != "failed":
+                raise ValueError(f"Operation {operation_id} is {row['status']} and can only be retried when failed")
+
+            task_payload = decode_jsonb(row["task_payload"], None)
+            if not isinstance(task_payload, dict):
+                raise ValueError(f"Operation {operation_id} cannot be retried (missing original task payload)")
+
+            task_type = task_payload.get("type")
+            if not isinstance(task_type, str) or not task_type.strip():
+                raise ValueError(f"Operation {operation_id} cannot be retried (invalid task payload type)")
+
+            # Rebuild payload with a new operation ID and reset retry counters.
+            new_task_payload = dict(task_payload)
+            new_task_payload["operation_id"] = str(new_op_uuid)
+            new_task_payload["bank_id"] = bank_id
+            new_task_payload["operation_type"] = row["operation_type"]
+            new_task_payload.pop("_retry_count", None)
+            new_task_payload.pop("_retry_at", None)
+            new_task_payload.pop("_claimed_at", None)
+            new_task_payload.pop("_worker_id", None)
+
+            metadata_payload = decode_jsonb(row["result_metadata"], {})
+            if not isinstance(metadata_payload, dict):
+                metadata_payload = {}
+            metadata_payload["operation_stage"] = "queued"
+            metadata_payload["retried_from_operation_id"] = operation_id
+            metadata_payload["retry_requested_at"] = datetime.now(UTC).isoformat()
+
+            async with conn.transaction():
+                await conn.execute(
+                    f"""
+                    INSERT INTO {fq_table("async_operations")}
+                      (operation_id, bank_id, operation_type, status, task_payload, result_metadata, created_at, updated_at)
+                    VALUES
+                      ($1, $2, $3, 'pending', $4::jsonb, $5::jsonb, NOW(), NOW())
+                    """,
+                    new_op_uuid,
+                    bank_id,
+                    row["operation_type"],
+                    json.dumps(new_task_payload),
+                    json.dumps(metadata_payload),
+                )
+
+            await self._task_backend.submit_task(new_task_payload)
+
+            logger.info(
+                "Retried failed operation bank_id=%s old_operation_id=%s new_operation_id=%s type=%s",
+                bank_id,
+                operation_id,
+                str(new_op_uuid),
+                row["operation_type"],
+            )
+
+            return {
+                "success": True,
+                "message": f"Retried operation {operation_id} as {new_op_uuid}",
+                "operation_id": str(new_op_uuid),
+                "retried_from_operation_id": operation_id,
+                "bank_id": bank_id,
+                "operation_type": row["operation_type"],
             }
 
     async def _cleanup_cancelled_operation_state(

--- a/atulya-control-plane/src/app/api/banks/[bankId]/operations/[operationId]/route.ts
+++ b/atulya-control-plane/src/app/api/banks/[bankId]/operations/[operationId]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { sdk, lowLevelClient } from "@/lib/atulya-client";
+import { DATAPLANE_URL, getDataplaneHeaders } from "@/lib/atulya-client";
 
 export async function GET(
   request: Request,
@@ -30,5 +31,40 @@ export async function GET(
   } catch (error) {
     console.error("Error getting operation status:", error);
     return NextResponse.json({ error: "Failed to get operation status" }, { status: 500 });
+  }
+}
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ bankId: string; operationId: string }> }
+) {
+  try {
+    const { bankId, operationId } = await params;
+
+    if (!bankId) {
+      return NextResponse.json({ error: "bank_id is required" }, { status: 400 });
+    }
+
+    if (!operationId) {
+      return NextResponse.json({ error: "operation_id is required" }, { status: 400 });
+    }
+
+    const response = await fetch(
+      `${DATAPLANE_URL}/v1/default/banks/${encodeURIComponent(bankId)}/operations/${encodeURIComponent(operationId)}/retry`,
+      {
+        method: "POST",
+        headers: getDataplaneHeaders({
+          "Content-Type": "application/json",
+        }),
+      }
+    );
+
+    const payload = await response
+      .json()
+      .catch(() => ({ error: "Failed to parse retry response" }));
+    return NextResponse.json(payload, { status: response.status });
+  } catch (error) {
+    console.error("Error retrying operation:", error);
+    return NextResponse.json({ error: "Failed to retry operation" }, { status: 500 });
   }
 }

--- a/atulya-control-plane/src/components/bank-operations-view.tsx
+++ b/atulya-control-plane/src/components/bank-operations-view.tsx
@@ -29,7 +29,7 @@ import {
 } from "@/components/ui/select";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { RefreshCw, Clock, AlertCircle, CheckCircle, Loader2, X } from "lucide-react";
+import { RefreshCw, Clock, AlertCircle, CheckCircle, Loader2, X, RotateCcw } from "lucide-react";
 
 interface Operation {
   id: string;
@@ -119,6 +119,7 @@ export function BankOperationsView() {
   const [limit] = useState(10);
   const [offset, setOffset] = useState(0);
   const [cancellingOpId, setCancellingOpId] = useState<string | null>(null);
+  const [retryingOpId, setRetryingOpId] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [selectedOperation, setSelectedOperation] = useState<OperationDetails | null>(null);
   const [selectedOperationResult, setSelectedOperationResult] = useState<
@@ -203,6 +204,20 @@ export function BankOperationsView() {
       setSelectedOperation({ error: "Failed to load operation details" });
     } finally {
       setLoadingDetails(false);
+    }
+  };
+
+  const handleRetryOperation = async (operationId: string) => {
+    if (!currentBank) return;
+
+    setRetryingOpId(operationId);
+    try {
+      await client.retryOperation(currentBank, operationId);
+      await loadOperations();
+    } catch (error) {
+      // Error toast is shown automatically by the API client interceptor
+    } finally {
+      setRetryingOpId(null);
     }
   };
 
@@ -367,6 +382,25 @@ export function BankOperationsView() {
                               <X className="w-3 h-3 mr-1" />
                             )}
                             {cancellingOpId === op.id ? "" : "Cancel"}
+                          </Button>
+                        )}
+                        {op.status === "failed" && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-7 text-xs text-muted-foreground hover:text-blue-600 dark:hover:text-blue-400"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleRetryOperation(op.id);
+                            }}
+                            disabled={retryingOpId === op.id}
+                          >
+                            {retryingOpId === op.id ? (
+                              <Loader2 className="w-3 h-3 animate-spin" />
+                            ) : (
+                              <RotateCcw className="w-3 h-3 mr-1" />
+                            )}
+                            {retryingOpId === op.id ? "" : "Retry"}
                           </Button>
                         )}
                       </TableCell>

--- a/atulya-control-plane/src/lib/api.ts
+++ b/atulya-control-plane/src/lib/api.ts
@@ -1868,6 +1868,22 @@ export class ControlPlaneClient {
   }
 
   /**
+   * Retry a failed async operation.
+   */
+  async retryOperation(bankId: string, operationId: string) {
+    return this.fetchApi<{
+      success: boolean;
+      message: string;
+      operation_id: string;
+      retried_from_operation_id: string;
+      bank_id: string;
+      operation_type: string | null;
+    }>(`/api/banks/${bankId}/operations/${operationId}`, {
+      method: "POST",
+    });
+  }
+
+  /**
    * Get the final result for an async operation
    */
   async getOperationResult(bankId: string, operationId: string) {


### PR DESCRIPTION
## Summary
- fix recall operation-id generation in `memory_engine.recall()` to prevent in-process ID collisions that were causing consolidation failures (`Operation recall-... already exists`)
- add backend endpoint `POST /v1/default/banks/{bank_id}/operations/{operation_id}/retry` to safely requeue failed async operations with a new operation ID and retry lineage metadata
- wire control-plane retry support end-to-end (API proxy route, client method, and Retry button in Background Operations for failed rows)

## Test plan
- [x] Run `bash scripts/generate-clients.sh`
- [x] Compile updated backend modules with `python3 -m py_compile atulya-api/atulya_api/engine/memory_engine.py atulya-api/atulya_api/api/http.py`
- [x] Validate retry endpoint success on a real failed operation:
  - `POST /v1/default/banks/cortex_default_255400280637643_lid/operations/{failed_op_id}/retry`
- [x] Validate non-failed operation is rejected by retry endpoint
- [x] Validate control-plane retry proxy route returns backend retry response
- [x] Pre-commit lint hooks pass

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new write-path behavior that inserts and re-queues async operations; incorrect validation or payload reconstruction could lead to duplicate/invalid tasks or unexpected operation state. The recall-id change is low risk but affects concurrency-sensitive execution paths.
> 
> **Overview**
> Fixes in-process `recall()` operation ID collisions by switching to a high-entropy `recall_id`, preventing `budgeted_operation` registration errors under concurrency.
> 
> Adds an end-to-end *failed-operation retry* flow: a new dataplane endpoint `POST /v1/default/banks/{bank_id}/operations/{operation_id}/retry` plus `MemoryEngine.retry_failed_operation()` to clone the original task payload, create a new pending `async_operations` row with retry lineage metadata, and re-submit the task.
> 
> Wires control-plane support by proxying the retry request, adding `client.retryOperation()`, and showing a `Retry` button for failed rows in Background Operations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c444cedfe356aa9f8cf350fa04b730c330527724. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->