### PR TITLE
Langfuse self-host + OTEL tracing fixes and GenAI IO on spans

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -136,20 +136,23 @@ ATULYA_API_BRAIN_STARTUP_WARMUP=true
 # For TEI provider:
 # ATULYA_API_RERANKER_TEI_URL=http://localhost:8081
 
-# Observability & Tracing (Optional - disabled by default)
-# Enable OpenTelemetry tracing for LLM calls (GenAI semantic conventions)
-# ATULYA_API_OTEL_TRACES_ENABLED=true
+# Observability & tracing (default: self-hosted Langfuse for LLM OTEL)
+# Stack: ./scripts/dev/start-langfuse.sh → http://localhost:3001 (see docker/docker-compose/langfuse/README.md)
+# In Langfuse UI: create a project → Settings → API keys → use public + secret below.
+ATULYA_API_OTEL_TRACES_ENABLED=true
+ATULYA_API_OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:3001/api/public/otel
+# Build:  echo -n 'pk-lf-xxxxxxxx:sk-lf-xxxxxxxx' | base64   (GNU Linux: add  -w 0  to base64)
+ATULYA_API_OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic REPLACE_WITH_BASE64_OF_PK_COLON_SK,x-langfuse-ingestion-version=4"
+ATULYA_API_OTEL_SERVICE_NAME=atulya-api
+ATULYA_API_OTEL_DEPLOYMENT_ENVIRONMENT=development
+# For atulya-worker only, you can set: ATULYA_API_OTEL_SERVICE_NAME=atulya-worker
 #
-# Local development with Grafana LGTM stack (recommended - see scripts/dev/grafana/README.md)
+# Alternative: Grafana LGTM (OTLP HTTP on 4318; Grafana UI on 3000 — see scripts/dev/monitoring/README.md)
 # ATULYA_API_OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+# ATULYA_API_OTEL_EXPORTER_OTLP_HEADERS=
 #
-# Cloud backends (Grafana Cloud, Langfuse, DataDog, etc.)
-# ATULYA_API_OTEL_EXPORTER_OTLP_ENDPOINT=https://your-backend-url
-# ATULYA_API_OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer your-token"
-#
-# Custom service name and environment (optional, defaults: atulya-api, development)
-# ATULYA_API_OTEL_SERVICE_NAME=atulya-production
-# ATULYA_API_OTEL_DEPLOYMENT_ENVIRONMENT=production
+# Langfuse Cloud (pick your region): https://langfuse.com/docs/opentelemetry/example-opentelemetry-collector
+# ATULYA_API_OTEL_EXPORTER_OTLP_ENDPOINT=https://cloud.langfuse.com/api/public/otel
 
 # Entity trajectories (optional — LLM + HMM-style progression per entity; default off)
 # When enabled, retain commits enqueue background jobs to recompute trajectories for touched entities.

--- a/atulya-api/atulya_api/engine/memory_engine.py
+++ b/atulya-api/atulya_api/engine/memory_engine.py
@@ -6963,6 +6963,7 @@ class MemoryEngine(MemoryEngineInterface):
             fusion_span.set_attribute("atulya.graph_count", len(graph_results))
             fusion_span.set_attribute("atulya.temporal_count", len(temporal_results) if temporal_results else 0)
 
+            merged_candidates: list = []
             try:
                 # Merge 3 or 4 result lists depending on temporal constraint
                 if temporal_results:

--- a/atulya-api/atulya_api/engine/reflect/agent.py
+++ b/atulya-api/atulya_api/engine/reflect/agent.py
@@ -1154,10 +1154,10 @@ async def _execute_tool_with_timing(
             from opentelemetry.trace import Status, StatusCode
 
             span.set_status(Status(StatusCode.ERROR, str(e)))
-            span.record_exception(e)
             duration_ms = int((time.time() - start_time) * 1000)
             span.set_attribute("atulya.tool.duration_ms", duration_ms)
             end_time_ns = time.time_ns()
+            span.record_exception(e, timestamp=end_time_ns)
             span.end(end_time=end_time_ns)
             raise
 

--- a/atulya-api/atulya_api/tracing.py
+++ b/atulya-api/atulya_api/tracing.py
@@ -12,6 +12,7 @@ to Langfuse (or any OTLP-compatible backend) via OTLP HTTP protocol.
 
 import json
 import logging
+import math
 import time
 from typing import Any, Optional
 
@@ -116,6 +117,9 @@ class GenAIAttributes:
 
     # Response metadata
     FINISH_REASONS = "gen_ai.response.finish_reasons"
+
+    # Full tool-call payloads on the span (Langfuse maps span attrs to IO; events alone are often hidden)
+    TOOL_CALLS_JSON = "gen_ai.tool_calls.json"
 
     # Error tracking
     ERROR_TYPE = "error.type"
@@ -247,6 +251,31 @@ def is_tracing_enabled() -> bool:
 MAX_CONTENT_LENGTH = 100_000  # characters
 
 
+def _safe_duration_seconds(duration: float) -> float:
+    """Sanitize LLM duration for span math (non-finite or negative → 0)."""
+    try:
+        d = float(duration)
+    except (TypeError, ValueError):
+        return 0.0
+    if not math.isfinite(d) or d < 0:
+        return 0.0
+    return d
+
+
+def _current_span_start_time_ns() -> int | None:
+    """Start time (ns since epoch) of the active recording span, if any."""
+    try:
+        span = trace.get_current_span()
+        if span is None or not span.is_recording():
+            return None
+        st = getattr(span, "start_time", None)
+        if st is None:
+            return None
+        return int(st)
+    except Exception:
+        return None
+
+
 def _truncate_content(content: str) -> str:
     """Truncate content if too large for span."""
     if len(content) > MAX_CONTENT_LENGTH:
@@ -311,15 +340,30 @@ class LLMSpanRecorder:
                 # Fallback to chat {model} if no scope provided
                 span_name = f"{operation_name} {model}"
 
-            # Calculate timestamps
-            end_time_ns = time.time_ns()
-            start_time_ns = end_time_ns - int(duration * 1_000_000_000)
+            # Start time is derived from LLM duration; span end is wall-clock when this block
+            # finishes. Use end_on_exit=True so the SDK ends the span *after* body work — that
+            # keeps default-timestamped add_event / record_exception events strictly before end(),
+            # which OTel requires. A fixed end_time_ns captured *before* the body + end_on_exit=False
+            # made events (or use_span's exception hook) land after the declared end → Langfuse 500
+            # "Invalid time value".
+            entry_ns = time.time_ns()
+            dur_s = _safe_duration_seconds(duration)
+            start_time_ns = entry_ns - int(dur_s * 1_000_000_000)
+            if start_time_ns < 0:
+                start_time_ns = 0
+            if start_time_ns > entry_ns:
+                start_time_ns = entry_ns
+            # Nested under atulya.retain / etc.: synthetic start can lie before parent span start.
+            parent_start_ns = _current_span_start_time_ns()
+            if parent_start_ns is not None and start_time_ns < parent_start_ns:
+                start_time_ns = parent_start_ns
+            if start_time_ns > entry_ns:
+                start_time_ns = entry_ns
 
-            # Create span with explicit timestamps
             with self.tracer.start_as_current_span(
                 span_name,
                 start_time=start_time_ns,
-                end_on_exit=False,  # We'll set end time manually
+                end_on_exit=True,
             ) as span:
                 # Set required attributes
                 span.set_attribute(GenAIAttributes.OPERATION_NAME, operation_name)
@@ -358,6 +402,21 @@ class LLMSpanRecorder:
                 if finish_reason:
                     event_attrs[GenAIAttributes.FINISH_REASONS] = json.dumps([finish_reason])
 
+                # Langfuse (and similar UIs) map generation input/output from **span attributes** such as
+                # gen_ai.input.messages / gen_ai.output.messages (see Langfuse OTEL property mapping).
+                # We still emit the same data on the semconv event for other collectors.
+                if input_messages_json:
+                    span.set_attribute(GenAIAttributes.INPUT_MESSAGES, input_messages_json)
+                if output_messages_json:
+                    span.set_attribute(GenAIAttributes.OUTPUT_MESSAGES, output_messages_json)
+                if system_instructions:
+                    span.set_attribute(GenAIAttributes.SYSTEM_INSTRUCTIONS, system_instructions)
+                if tool_calls:
+                    try:
+                        span.set_attribute(GenAIAttributes.TOOL_CALLS_JSON, json.dumps(tool_calls))
+                    except (TypeError, ValueError):
+                        span.set_attribute(GenAIAttributes.TOOL_CALLS_JSON, "[]")
+
                 span.add_event(
                     "gen_ai.client.inference.operation.details",
                     attributes=event_attrs,
@@ -371,7 +430,10 @@ class LLMSpanRecorder:
                             "tool.id": tc.get("id", ""),
                             "tool.arguments": json.dumps(tc.get("arguments", {})),
                         }
-                        span.add_event(f"gen_ai.tool_call.{i}", attributes=tool_event_attrs)
+                        span.add_event(
+                            f"gen_ai.tool_call.{i}",
+                            attributes=tool_event_attrs,
+                        )
 
                 # Handle errors
                 if error:
@@ -380,9 +442,6 @@ class LLMSpanRecorder:
                     span.record_exception(error)
                 else:
                     span.set_status(Status(StatusCode.OK))
-
-                # Set end time
-                span.end(end_time=end_time_ns)
 
         except Exception as e:
             # Don't let tracing errors break LLM calls

--- a/atulya-api/tests/test_tracing.py
+++ b/atulya-api/tests/test_tracing.py
@@ -169,6 +169,7 @@ def test_llm_span_recorder_record_success(mock_time):
     mock_tracer.start_as_current_span.assert_called_once()
     call_args = mock_tracer.start_as_current_span.call_args
     assert call_args[0][0] == "atulya.test"
+    assert call_args[1].get("end_on_exit") is True
 
     # Verify attributes were set
     assert mock_span.set_attribute.called
@@ -182,6 +183,12 @@ def test_llm_span_recorder_record_success(mock_time):
     assert attribute_calls[GenAIAttributes.USAGE_OUTPUT_TOKENS] == 5
     assert attribute_calls["atulya.scope"] == "test"
 
+    # Prompt / completion on span (Langfuse maps these; not only on span events)
+    assert GenAIAttributes.INPUT_MESSAGES in attribute_calls
+    assert GenAIAttributes.OUTPUT_MESSAGES in attribute_calls
+    assert '"Hello"' in attribute_calls[GenAIAttributes.INPUT_MESSAGES]
+    assert "Hi there!" in attribute_calls[GenAIAttributes.OUTPUT_MESSAGES]
+
     # Verify event was added
     mock_span.add_event.assert_called_once()
     event_call = mock_span.add_event.call_args
@@ -190,8 +197,7 @@ def test_llm_span_recorder_record_success(mock_time):
     # Verify status was set to OK
     mock_span.set_status.assert_called()
 
-    # Verify span was ended
-    mock_span.end.assert_called_once()
+    # Span end is performed by the SDK context manager (end_on_exit=True), not mock_span.end()
 
 
 @patch("atulya_api.tracing.time")
@@ -232,7 +238,7 @@ def test_llm_span_recorder_record_error(mock_time):
     attribute_calls = {call[0][0]: call[0][1] for call in mock_span.set_attribute.call_args_list}
     assert attribute_calls[GenAIAttributes.ERROR_TYPE] == "ValueError"
 
-    # Verify exception was recorded
+    # Verify exception was recorded (during span, before auto end_on_exit)
     mock_span.record_exception.assert_called_once_with(error)
 
 

--- a/docker/docker-compose/langfuse/README.md
+++ b/docker/docker-compose/langfuse/README.md
@@ -1,0 +1,77 @@
+# Langfuse (self-hosted) for Atulya OTEL
+
+Docker Compose stack for [Langfuse](https://langfuse.com/) aligned with the upstream [docker-compose.yml](https://github.com/langfuse/langfuse/blob/main/docker-compose.yml). Atulya sends OpenTelemetry traces to Langfuse’s HTTP OTLP endpoint (`/api/public/otel`; see [Langfuse OTEL docs](https://langfuse.com/docs/opentelemetry/example-opentelemetry-collector)).
+
+This layout lives under **`docker/docker-compose/langfuse/`**, consistent with other stacks such as [`timescale`](../timescale/README.md) and [`vchord`](../vchord/docker-compose.yaml).
+
+## Prerequisites
+
+- Docker with Compose v2
+- Shared external network **`atulya-network`** (same as `scripts/dev/monitoring`). Create if missing:
+
+```bash
+docker network create atulya-network
+```
+
+## Quick start
+
+From the **Atulya repo root** (directory that contains `docker/` and `atulya-api/`):
+
+```bash
+./docker/docker-compose/langfuse/start.sh
+```
+
+Or explicitly:
+
+```bash
+docker compose -f docker/docker-compose/langfuse/docker-compose.yaml up -d
+```
+
+- **Langfuse UI**: http://localhost:3001 (port **3001** so it does not collide with Grafana LGTM on **3000**)
+- **MinIO** (S3 API): http://localhost:9090
+- **Langfuse Postgres (host only)**: `127.0.0.1:15432` → container `5432`. Langfuse services use `postgres:5432` inside Docker; this mapping is only if you need `psql` from the host. **15432** is used so this stack does not bind **5432** (Atulya embedded / dev Postgres).
+
+Wait until `langfuse-web` logs show Ready (~2–3 minutes on first boot).
+
+## Secrets
+
+Before any non-local use, replace defaults for `SALT`, `ENCRYPTION_KEY`, `NEXTAUTH_SECRET`, `POSTGRES_PASSWORD`, `CLICKHOUSE_PASSWORD`, `REDIS_AUTH`, MinIO credentials, and Langfuse S3-related secrets (see upstream compose comments). Generate `ENCRYPTION_KEY` with `openssl rand -hex 32`.
+
+## Atulya environment
+
+Create a Langfuse project in the UI and copy **public** and **secret** keys. Set:
+
+```bash
+ATULYA_API_OTEL_TRACES_ENABLED=true
+ATULYA_API_OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:3001/api/public/otel
+ATULYA_API_OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic <AUTH_B64>,x-langfuse-ingestion-version=4"
+```
+
+Build `AUTH_B64`:
+
+```bash
+echo -n 'pk-lf-...:sk-lf-...' | base64
+# GNU: add -w 0 to avoid line wrapping
+```
+
+Use **OTLP over HTTP** only; Langfuse does not accept gRPC on this path. Postgres and ClickHouse must use **UTC** (already set in this compose).
+
+## Grafana LGTM
+
+If you run the [dev monitoring stack](../../../scripts/dev/monitoring/README.md) (Grafana LGTM), keep Grafana on **3000** and Langfuse on **3001**.
+
+## Troubleshooting
+
+- Images are pinned to **3.172.1** (web + worker). Older pins (for example **3.22.x**) could return **500** on `POST /api/public/otel/v1/traces` with server logs like `RangeError: Invalid time value` when mapping OTLP spans. After bumping the tag, run `docker compose -f docker/docker-compose/langfuse/docker-compose.yaml pull && docker compose -f docker/docker-compose/langfuse/docker-compose.yaml up -d`.
+- Traces missing after self-host upgrade: see Langfuse [self-host troubleshooting](https://langfuse.com/self-hosting/troubleshooting-and-faq) and [issue #8424](https://github.com/langfuse/langfuse/issues/8424) class reports for OTLP edge cases.
+- Stop: `docker compose -f docker/docker-compose/langfuse/docker-compose.yaml down` (add `-v` to drop volumes).
+
+## Convenience wrapper
+
+From repo root you can also run:
+
+```bash
+./scripts/dev/start-langfuse.sh
+```
+
+That delegates to `docker/docker-compose/langfuse/start.sh`.

--- a/docker/docker-compose/langfuse/docker-compose.yaml
+++ b/docker/docker-compose/langfuse/docker-compose.yaml
@@ -1,0 +1,200 @@
+# Derived from https://github.com/langfuse/langfuse/blob/main/docker-compose.yml
+# Atulya overrides: external network atulya-network, Langfuse web on host port 3001 (avoids
+# clash with Grafana LGTM on 3000), NEXTAUTH_URL for that port, pinned image tags.
+# Replace weak default secrets before shared or production use (see README).
+#
+# Upgrade images: docker compose pull && docker compose up -d
+# See: https://langfuse.com/self-hosting/deployment/docker-compose
+
+services:
+  langfuse-worker:
+    image: docker.io/langfuse/langfuse-worker:3.172.1
+    restart: unless-stopped
+    depends_on: &langfuse_depends_on
+      postgres:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
+    ports:
+      - "127.0.0.1:3030:3030"
+    networks:
+      - default
+    environment: &langfuse_worker_env
+      NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:3001}
+      DATABASE_URL: ${DATABASE_URL:-postgresql://postgres:postgres@postgres:5432/postgres}
+      SALT: ${SALT:-mysalt}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:-0000000000000000000000000000000000000000000000000000000000000000}
+      TELEMETRY_ENABLED: ${TELEMETRY_ENABLED:-true}
+      LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES: ${LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES:-false}
+      CLICKHOUSE_MIGRATION_URL: ${CLICKHOUSE_MIGRATION_URL:-clickhouse://clickhouse:9000}
+      CLICKHOUSE_URL: ${CLICKHOUSE_URL:-http://clickhouse:8123}
+      CLICKHOUSE_USER: ${CLICKHOUSE_USER:-clickhouse}
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-clickhouse}
+      CLICKHOUSE_CLUSTER_ENABLED: ${CLICKHOUSE_CLUSTER_ENABLED:-false}
+      LANGFUSE_USE_AZURE_BLOB: ${LANGFUSE_USE_AZURE_BLOB:-false}
+      LANGFUSE_USE_OCI_NATIVE_OBJECT_STORAGE: ${LANGFUSE_USE_OCI_NATIVE_OBJECT_STORAGE:-false}
+      LANGFUSE_OCI_AUTH_TYPE: ${LANGFUSE_OCI_AUTH_TYPE:-workload_identity}
+      LANGFUSE_S3_EVENT_UPLOAD_BUCKET: ${LANGFUSE_S3_EVENT_UPLOAD_BUCKET:-langfuse}
+      LANGFUSE_S3_EVENT_UPLOAD_REGION: ${LANGFUSE_S3_EVENT_UPLOAD_REGION:-auto}
+      LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: ${LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID:-minio}
+      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: ${LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY:-miniosecret}
+      LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: ${LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT:-http://minio:9000}
+      LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: ${LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE:-true}
+      LANGFUSE_S3_EVENT_UPLOAD_PREFIX: ${LANGFUSE_S3_EVENT_UPLOAD_PREFIX:-events/}
+      LANGFUSE_S3_MEDIA_UPLOAD_BUCKET: ${LANGFUSE_S3_MEDIA_UPLOAD_BUCKET:-langfuse}
+      LANGFUSE_S3_MEDIA_UPLOAD_REGION: ${LANGFUSE_S3_MEDIA_UPLOAD_REGION:-auto}
+      LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID: ${LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID:-minio}
+      LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY: ${LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY:-miniosecret}
+      LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT: ${LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT:-http://localhost:9090}
+      LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE: ${LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE:-true}
+      LANGFUSE_S3_MEDIA_UPLOAD_PREFIX: ${LANGFUSE_S3_MEDIA_UPLOAD_PREFIX:-media/}
+      LANGFUSE_S3_BATCH_EXPORT_ENABLED: ${LANGFUSE_S3_BATCH_EXPORT_ENABLED:-false}
+      LANGFUSE_S3_BATCH_EXPORT_BUCKET: ${LANGFUSE_S3_BATCH_EXPORT_BUCKET:-langfuse}
+      LANGFUSE_S3_BATCH_EXPORT_PREFIX: ${LANGFUSE_S3_BATCH_EXPORT_PREFIX:-exports/}
+      LANGFUSE_S3_BATCH_EXPORT_REGION: ${LANGFUSE_S3_BATCH_EXPORT_REGION:-auto}
+      LANGFUSE_S3_BATCH_EXPORT_ENDPOINT: ${LANGFUSE_S3_BATCH_EXPORT_ENDPOINT:-http://minio:9000}
+      LANGFUSE_S3_BATCH_EXPORT_EXTERNAL_ENDPOINT: ${LANGFUSE_S3_BATCH_EXPORT_EXTERNAL_ENDPOINT:-http://localhost:9090}
+      LANGFUSE_S3_BATCH_EXPORT_ACCESS_KEY_ID: ${LANGFUSE_S3_BATCH_EXPORT_ACCESS_KEY_ID:-minio}
+      LANGFUSE_S3_BATCH_EXPORT_SECRET_ACCESS_KEY: ${LANGFUSE_S3_BATCH_EXPORT_SECRET_ACCESS_KEY:-miniosecret}
+      LANGFUSE_S3_BATCH_EXPORT_FORCE_PATH_STYLE: ${LANGFUSE_S3_BATCH_EXPORT_FORCE_PATH_STYLE:-true}
+      LANGFUSE_INGESTION_QUEUE_DELAY_MS: ${LANGFUSE_INGESTION_QUEUE_DELAY_MS:-}
+      LANGFUSE_INGESTION_CLICKHOUSE_WRITE_INTERVAL_MS: ${LANGFUSE_INGESTION_CLICKHOUSE_WRITE_INTERVAL_MS:-}
+      REDIS_HOST: ${REDIS_HOST:-redis}
+      REDIS_PORT: ${REDIS_PORT:-6379}
+      REDIS_AUTH: ${REDIS_AUTH:-myredissecret}
+      REDIS_TLS_ENABLED: ${REDIS_TLS_ENABLED:-false}
+      REDIS_TLS_CA: ${REDIS_TLS_CA:-/certs/ca.crt}
+      REDIS_TLS_CERT: ${REDIS_TLS_CERT:-/certs/redis.crt}
+      REDIS_TLS_KEY: ${REDIS_TLS_KEY:-/certs/redis.key}
+      EMAIL_FROM_ADDRESS: ${EMAIL_FROM_ADDRESS:-}
+      SMTP_CONNECTION_URL: ${SMTP_CONNECTION_URL:-}
+
+  langfuse-web:
+    image: docker.io/langfuse/langfuse:3.172.1
+    restart: unless-stopped
+    depends_on: *langfuse_depends_on
+    ports:
+      - "3001:3000"
+    networks:
+      - default
+    environment:
+      <<: *langfuse_worker_env
+      NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:-mysecret}
+      LANGFUSE_INIT_ORG_ID: ${LANGFUSE_INIT_ORG_ID:-}
+      LANGFUSE_INIT_ORG_NAME: ${LANGFUSE_INIT_ORG_NAME:-}
+      LANGFUSE_INIT_PROJECT_ID: ${LANGFUSE_INIT_PROJECT_ID:-}
+      LANGFUSE_INIT_PROJECT_NAME: ${LANGFUSE_INIT_PROJECT_NAME:-}
+      LANGFUSE_INIT_PROJECT_PUBLIC_KEY: ${LANGFUSE_INIT_PROJECT_PUBLIC_KEY:-}
+      LANGFUSE_INIT_PROJECT_SECRET_KEY: ${LANGFUSE_INIT_PROJECT_SECRET_KEY:-}
+      LANGFUSE_INIT_USER_EMAIL: ${LANGFUSE_INIT_USER_EMAIL:-}
+      LANGFUSE_INIT_USER_NAME: ${LANGFUSE_INIT_USER_NAME:-}
+      LANGFUSE_INIT_USER_PASSWORD: ${LANGFUSE_INIT_USER_PASSWORD:-}
+
+  clickhouse:
+    image: docker.io/clickhouse/clickhouse-server:24.12-alpine
+    restart: unless-stopped
+    user: "101:101"
+    networks:
+      - default
+    environment:
+      CLICKHOUSE_DB: default
+      CLICKHOUSE_USER: ${CLICKHOUSE_USER:-clickhouse}
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-clickhouse}
+      TZ: UTC
+    volumes:
+      - langfuse_clickhouse_data:/var/lib/clickhouse
+      - langfuse_clickhouse_logs:/var/log/clickhouse-server
+    ports:
+      - "127.0.0.1:8123:8123"
+      - "127.0.0.1:9000:9000"
+    # Use 127.0.0.1 (not localhost): wget resolves localhost to [::1] first; CH HTTP
+    # listens on IPv4 only, so ::1 gives "Connection refused" and the service stays unhealthy.
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://127.0.0.1:8123/ping || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
+  minio:
+    image: cgr.dev/chainguard/minio:latest
+    restart: unless-stopped
+    entrypoint: sh
+    command: -c 'mkdir -p /data/langfuse && minio server --address ":9000" --console-address ":9001" /data'
+    networks:
+      - default
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minio}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-miniosecret}
+    ports:
+      - "9090:9000"
+      - "127.0.0.1:9091:9001"
+    volumes:
+      - langfuse_minio_data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 1s
+      timeout: 5s
+      retries: 5
+      start_period: 1s
+
+  redis:
+    image: docker.io/redis:7.4-alpine
+    restart: unless-stopped
+    command: >
+      --requirepass ${REDIS_AUTH:-myredissecret}
+      --maxmemory-policy noeviction
+    networks:
+      - default
+    ports:
+      - "127.0.0.1:6379:6379"
+    volumes:
+      - langfuse_redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_AUTH:-myredissecret}", "ping"]
+      interval: 3s
+      timeout: 10s
+      retries: 10
+
+  postgres:
+    image: docker.io/postgres:17-bookworm
+    restart: unless-stopped
+    networks:
+      - default
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 3s
+      timeout: 3s
+      retries: 10
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-postgres}
+      TZ: UTC
+      PGTZ: UTC
+    # Host 15432 avoids clashing with embedded / dev Postgres on localhost:5432
+    ports:
+      - "127.0.0.1:15432:5432"
+    volumes:
+      - langfuse_postgres_data:/var/lib/postgresql/data
+
+volumes:
+  langfuse_postgres_data:
+    driver: local
+  langfuse_clickhouse_data:
+    driver: local
+  langfuse_clickhouse_logs:
+    driver: local
+  langfuse_minio_data:
+    driver: local
+  langfuse_redis_data:
+    driver: local
+
+networks:
+  default:
+    name: atulya-network
+    external: true

--- a/docker/docker-compose/langfuse/start.sh
+++ b/docker/docker-compose/langfuse/start.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Start Langfuse from the Atulya repository root (parent of docker/).
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ATULYA_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+COMPOSE_REL="docker/docker-compose/langfuse/docker-compose.yaml"
+COMPOSE_FILE="$ATULYA_ROOT/$COMPOSE_REL"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is required" >&2
+  exit 12
+fi
+
+if ! docker network inspect atulya-network >/dev/null 2>&1; then
+  echo "Creating docker network atulya-network (required; same as dev monitoring stack)"
+  docker network create atulya-network
+fi
+
+cd "$ATULYA_ROOT"
+
+if [ "$#" -eq 0 ]; then
+  docker compose -f "$COMPOSE_REL" up -d
+  echo ""
+  echo "Langfuse UI:  http://localhost:3001"
+  echo "OTLP base:    http://localhost:3001/api/public/otel  (Atulya appends /v1/traces)"
+  echo "MinIO (S3):   http://localhost:9090"
+  echo ""
+  echo "Logs: docker compose -f $COMPOSE_REL logs -f langfuse-web"
+else
+  docker compose -f "$COMPOSE_REL" "$@"
+fi

--- a/scripts/dev/start-langfuse.sh
+++ b/scripts/dev/start-langfuse.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Thin wrapper: Langfuse compose lives under docker/docker-compose/langfuse/ (see README there).
+exec "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../../docker/docker-compose/langfuse/start.sh" "$@"


### PR DESCRIPTION
## Summary

Adds a **self-hosted Langfuse** Docker stack under `docker/docker-compose/langfuse/` and improves **OpenTelemetry** export so traces ingest reliably into Langfuse and show **full LLM input/output** (not only token counts).

## Langfuse stack

- Compose: web + worker, Postgres (host **15432** to avoid clashing with local Postgres), ClickHouse, MinIO, Redis; joins **`atulya-network`**.
- ClickHouse healthcheck uses **`127.0.0.1`** (avoids IPv6 `localhost` flakiness).
- Images pinned to **3.172.1** (avoids older OTLP ingest bugs such as `Invalid time value` on `/api/public/otel/v1/traces`).
- **README** + `start.sh`; thin wrapper **`scripts/dev/start-langfuse.sh`** from repo root.

## OTEL / tracing (API)

- **LLM spans:** safer duration math, synthetic `start_time` clamped to parent span start, **`end_on_exit=True`** so events/exceptions stay inside the span window (valid OTEL + friendlier to Langfuse).
- **`memory_engine`:** `merged_candidates` initialized before fusion `try` so `finally` cannot `NameError`.
- **`reflect`:** `record_exception` uses an explicit timestamp aligned with span end on error paths.
- **Langfuse UI:** duplicate GenAI payload on **span attributes** (`gen_ai.input.messages`, `gen_ai.output.messages`, `gen_ai.system_instructions`, `gen_ai.tool_calls.json`) in addition to the semconv **event**, because Langfuse maps generation IO from span attributes.

## Configuration

- **`.env.example`:** documents `ATULYA_API_OTEL_*` and Langfuse OTLP URL/header pattern (`x-langfuse-ingestion-version=4`, Basic auth).

## How to verify

1. Start Langfuse: `./scripts/dev/start-langfuse.sh` (or compose file under `docker/docker-compose/langfuse/`).
2. Set OTLP env from `.env.example`, restart API, run a flow that calls an LLM.
3. In Langfuse, open a generation: **Input / Output** should show messages; traces should not 500 on OTLP ingest.

## Tests

- `uv run pytest atulya-api/tests/test_tracing.py`

---

**Note:** `.env` with real keys is not part of this PR; rotate keys if they were ever committed or shared elsewhere.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes OpenTelemetry span timestamping/attribute emission and enables tracing by default in `.env.example`, which could affect trace export behavior and payload sizes but does not alter core business logic.
> 
> **Overview**
> Adds a **self-hosted Langfuse** Docker Compose stack (web/worker + Postgres/ClickHouse/MinIO/Redis) with helper scripts so developers can run Langfuse locally on port `3001` and share the `atulya-network`.
> 
> Hardens **OTEL LLM tracing** to avoid Langfuse ingest errors by sanitizing duration-derived timestamps, clamping synthetic span start times, and letting the SDK end spans (`end_on_exit=True`) so events/exceptions fall within the span window; also records full GenAI IO (messages, system prompt, tool calls) on **span attributes** for Langfuse UI mapping. Fixes a small recall fusion bug by initializing `merged_candidates` before the `try/finally`, and updates tracing tests and `.env.example` with Langfuse OTLP endpoint/header guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65d4ec9a3e531d4711e4f88e98f3b4663a8ca8c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->